### PR TITLE
feat: add studio view handler for instructors to configure limesurvey

### DIFF
--- a/limesurvey/static/css/limesurvey.css
+++ b/limesurvey/static/css/limesurvey.css
@@ -1,9 +1,1 @@
 /* CSS for LimeSurveyXBlock */
-
-.limesurvey_block .count {
-    font-weight: bold;
-}
-
-.limesurvey_block p {
-    cursor: pointer;
-}

--- a/limesurvey/static/html/limesurvey.html
+++ b/limesurvey/static/html/limesurvey.html
@@ -1,5 +1,3 @@
 <div class="limesurvey_block">
-<p>LimeSurveyXBlock: count is now
-    <span class='count'>{self.count}</span> (click me to increment).
-</p>
+<p>LimeSurveyXBlock</p>
 </div>

--- a/limesurvey/static/html/limesurvey_edit.html
+++ b/limesurvey/static/html/limesurvey_edit.html
@@ -1,0 +1,33 @@
+<div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
+  <ul class="list-input settings-list">
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="limesurvey_display_name">Display name</label>
+        <input class="input setting-input" name="limesurvey_display_name" id="limesurvey_display_name" value="{display_name}" type="text" />
+      </div>
+    </li>
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="limesurvey_access_key">Access key for API authentication</label>
+        <input class="input setting-input" name="limesurvey_access_key" id="limesurvey_access_key" value="{access_key}" type="text" />
+      </div>
+    </li>
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="limesurvey_survey_id">Survey ID</label>
+        <input class="input setting-input" name="limesurvey_survey_id" id="limesurvey_survey_id" value="{survey_id}" type="text" />
+      </div>
+    </li>
+  </ul>
+
+  <div class="xblock-actions">
+    <ul>
+      <li class="action-item">
+        <a href="#" class="button action-primary save-button">Save</a>
+      </li>
+      <li class="action-item">
+        <a href="#" class="button cancel-button">Cancel</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/limesurvey/static/js/src/limesurveyEdit.js
+++ b/limesurvey/static/js/src/limesurveyEdit.js
@@ -1,0 +1,19 @@
+/* Javascript for LimeSurveyXBlock. */
+function LimeSurveyXBlock(runtime, element) {
+
+    $(element).find('.save-button').bind('click', function() {
+        var handlerUrl = runtime.handlerUrl(element, 'studio_submit');
+        var data = {
+            display_name: $(element).find('input[name=limesurvey_display_name]').val(),
+            access_key: $(element).find('input[name=limesurvey_access_key]').val(),
+            survey_id: $(element).find('input[name=limesurvey_survey_id]').val(),
+        };
+        $.post(handlerUrl, JSON.stringify(data)).done(function(response) {
+          window.location.reload(false);
+        });
+      });
+
+    $(element).find('.cancel-button').bind('click', function() {
+        runtime.notify('cancel', {});
+    });
+}


### PR DESCRIPTION
### Description
This PR adds the studio view handler for the limesurvey block. It renders the configuration view for instructors to configure in Studio. This is the 1st approach, a detailed description and more fields might be needed. 

### How to test
1. Install this branch in your environment
2. Add the xblock to your course following the instructions in the readme file
3. Edit the xblock and configure it
4. Save
5. Open it again, it should show your previous configuration