### PR TITLE
fix: fix split error in add_participant_to_survey method

### DIFF
--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -1,4 +1,5 @@
 """TO-DO: Write a description of what this XBlock is."""
+from typing import Tuple
 
 import pkg_resources
 import requests
@@ -148,6 +149,28 @@ class LimeSurveyXBlock(XBlock):
 
         return response.get("result").get("token")
 
+    @staticmethod
+    def get_fullname(user) -> Tuple[str, str]:
+        """
+        Return the full name of the user.
+
+        args:
+            user: The user to get the fullname
+
+        returns:
+            A tuple containing the first name and last name of the user
+        """
+        first_name, last_name = "", ""
+
+        if user.profile.name:
+            fullname = user.profile.name.split(" ", 1)
+            first_name = fullname[0]
+
+            if fullname[1:]:
+                last_name = fullname[1]
+
+        return first_name, last_name
+
     def add_participant_to_survey(self, user, anonymous_user_id: str):
         """
         Add the student as participant to specified survey.
@@ -156,14 +179,7 @@ class LimeSurveyXBlock(XBlock):
             user: The user to add as participant
             anonymous_user_id: The anonymous user id of the user
         """
-        firstname, lastname = None, None
-
-        if user.profile.name is not None:
-            fullname = user.profile.name.split()
-            if len(fullname) > 1:
-                firstname, lastname = fullname
-            else:
-                firstname = fullname[0]
+        firstname, lastname = self.get_fullname(user)
 
         participant = {
             "email": user.email,

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -148,11 +148,22 @@ class LimeSurveyXBlock(XBlock):
 
         return response.get("result").get("token")
 
-    def add_participant_to_survey(self, user, anonymous_user_id):
+    def add_participant_to_survey(self, user, anonymous_user_id: str):
         """
         Add the student as participant to specified survey.
+
+        args:
+            user: The user to add as participant
+            anonymous_user_id: The anonymous user id of the user
         """
-        firstname, lastname = user.profile.name.split()
+        firstname, lastname = None, None
+
+        if user.profile.name is not None:
+            fullname = user.profile.name.split()
+            if len(fullname) > 1:
+                firstname, lastname = fullname
+            else:
+                firstname = fullname[0]
 
         participant = {
             "email": user.email,


### PR DESCRIPTION
### Description
This PR fix the split error when obtain the fullname of the user.

### How to test
1. Configure a survey as in [this PR](https://github.com/eduNEXT/xblock-limesurvey/pull/3)
2. In Studio add or edit the unit with the XBlock, and edit the configuration changing the **Access key for API authentication** and **Survey ID**. 
3. Create an user without the fullname (None), or with only 1 word, e.g. (_John_).
4. Enroll the user to the course.
5. From the LMS access to the unit with the XBlock. The XBlock should run correctly.
6. Verify that the user was added to the survey in the LimeSurvey Admin.