### PR TITLE
fix: avoid duplicate user in the survey

### DIFF
--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -267,9 +267,7 @@ class LimeSurveyXBlock(XBlock):
         """
         Show the survey URL and access code to the user
         """
-        URL = "http://limesurvey.local.overhang.io:8082"
-
-        self.survey_url = f"{URL}/{self.survey_id}"
+        self.survey_url = f"{settings.LIMESURVEY_URL}/{self.survey_id}"
         self.access_code = "aMGZtTyFFVhhA0z"
 
         return {"survey_url": self.survey_url, "access_code": self.access_code}

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -177,13 +177,20 @@ class LimeSurveyXBlock(XBlock):
     def user_in_survey(self, anonymous_user_id: str) -> bool:
         """
         Check if the user is already in the survey.
+        - `params` variable is a list of parameters to pass to the API call.
+            - params[0]: Survey ID
+            - params[1]: Retrieve participants starting from this index
+            - params[2]: Maximum number of participants to retrieve
+            - params[3]: Retrieve only participants with unused tokens
+            - params[4]: List with extra participant attributes to retrieve
+            - params[5]: Dictionary of conditions to filter participants
 
-        Args:
+        args:
             anonymous_user_id (str): The anonymous user ID
+
         """
         params = [
-            self.survey_id, 0, 1, False,
-            ["attribute_1"], {"attribute_1": anonymous_user_id}
+            self.survey_id, 0, 1, False, ["attribute_1"], {"attribute_1": anonymous_user_id}
         ]
 
         response = self._invoke("list_participants", *params)

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -104,7 +104,8 @@ class LimeSurveyXBlock(XBlock):
 
         if show_survey:
             anonymous_user_id = self.anonymous_user_id(user)
-            self.add_participant_to_survey(user, anonymous_user_id)
+            if not self.user_in_survey(anonymous_user_id):
+                self.add_participant_to_survey(user, anonymous_user_id)
 
         context = {"self": self, "show_survey": show_survey}
         html = self.render_template("static/html/limesurvey.html", context)
@@ -173,7 +174,26 @@ class LimeSurveyXBlock(XBlock):
             "access_code": self.access_code,
         }
 
-    def get_student_access_code(self, anonymous_user_id) -> str:
+    def user_in_survey(self, anonymous_user_id: str) -> bool:
+        """
+        Check if the user is already in the survey.
+
+        Args:
+            anonymous_user_id (str): The anonymous user ID
+        """
+        params = [
+            self.survey_id, 0, 1, False,
+            ["attribute_1"], {"attribute_1": anonymous_user_id}
+        ]
+
+        response = self._invoke("list_participants", *params)
+
+        if isinstance(response.get("result"), list):
+            return len(response.get("result")) > 0
+
+        return False
+
+    def get_student_access_code(self, anonymous_user_id):
         """
         Return the access code for the current user.
 

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -177,23 +177,27 @@ class LimeSurveyXBlock(XBlock):
     def user_in_survey(self, anonymous_user_id: str) -> bool:
         """
         Check if the user is already in the survey.
-        - `params` variable is a list of parameters to pass to the API call.
-            - params[0]: Survey ID
-            - params[1]: Retrieve participants starting from this index
-            - params[2]: Maximum number of participants to retrieve
-            - params[3]: Retrieve only participants with unused tokens
-            - params[4]: List with extra participant attributes to retrieve
-            - params[5]: Dictionary of conditions to filter participants
+        - `params` variable is a dict of parameters to pass to the API call.
+            - survey_id: The ID of the survey
+            - start: Retrieve participants starting from this index
+            - limit: Maximum number of participants to retrieve
+            - unused: Retrieve only participants with unused tokens
+            - attributes: List with extra participant attributes to retrieve
+            - conditions: Dictionary of conditions to filter participants
 
         args:
             anonymous_user_id (str): The anonymous user ID
-
         """
-        params = [
-            self.survey_id, 0, 1, False, ["attribute_1"], {"attribute_1": anonymous_user_id}
-        ]
+        params = {
+            "survey_id": self.survey_id,
+            "start": 0,
+            "limit": 1,
+            "unused": False,
+            "attributes": ["attribute_1"],
+            "conditions": {"attribute_1": anonymous_user_id},
+        }
 
-        response = self._invoke("list_participants", *params)
+        response = self._invoke("list_participants", *params.values())
 
         if isinstance(response.get("result"), list):
             return len(response.get("result")) > 0

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -262,6 +262,18 @@ class LimeSurveyXBlock(XBlock):
 
         return response.json()
 
+    @XBlock.json_handler
+    def get_survey_url(self, data, suffix=''): # pylint: disable=unused-argument
+        """
+        Show the survey URL and access code to the user
+        """
+        URL = "http://limesurvey.local.overhang.io:8082"
+
+        self.survey_url = f"{URL}/{self.survey_id}"
+        self.access_code = "aMGZtTyFFVhhA0z"
+
+        return {"survey_url": self.survey_url, "access_code": self.access_code}
+
     # TO-DO: change this to create the scenarios you'd like to see in the
     # workbench while developing your XBlock.
     @staticmethod

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -262,54 +262,6 @@ class LimeSurveyXBlock(XBlock):
 
         return response.json()
 
-    @XBlock.json_handler
-    def get_survey_url(self, data, suffix=''): # pylint: disable=unused-argument
-        """
-        Show the survey URL and access code to the user
-        """
-        self.survey_url = f"{settings.LIMESURVEY_URL}/{self.survey_id}"
-
-        anonymous_user_id = self.runtime.anonymous_student_id
-        user = self.runtime.get_real_user(anonymous_user_id)
-        firstname, lastname = user.profile.name.split()
-
-        # add user to the survey
-        payload = {
-            "method": "add_participants",
-            "params": [
-                self.access_key,
-                self.survey_id,
-                [
-                    {
-                        "email": user.email,
-                        "lastname": lastname,
-                        "firstname": firstname,
-                        "attribute_1": anonymous_user_id,
-                    }
-                ]
-            ],
-            "id": 1,
-        }
-
-        # TO-DO: avoid duplicate user in the survey
-        requests.post(settings.LIMESURVEY_INTERNAL_API, json=payload).json()
-
-        # Get the access code for the user
-        payload = {
-            "method": "get_participant_properties",
-            "params": [
-                self.access_key,
-                self.survey_id,
-                {"attribute_1": anonymous_user_id},
-            ],
-            "id": 1,
-        }
-
-        response = requests.post(settings.LIMESURVEY_INTERNAL_API, json=payload).json()
-        self.access_code = response["result"]["token"]
-
-        return {"survey_url": self.survey_url, "access_code": self.access_code}
-
     # TO-DO: change this to create the scenarios you'd like to see in the
     # workbench while developing your XBlock.
     @staticmethod

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -268,7 +268,45 @@ class LimeSurveyXBlock(XBlock):
         Show the survey URL and access code to the user
         """
         self.survey_url = f"{settings.LIMESURVEY_URL}/{self.survey_id}"
-        self.access_code = "aMGZtTyFFVhhA0z"
+
+        anonymous_user_id = self.runtime.anonymous_student_id
+        user = self.runtime.get_real_user(anonymous_user_id)
+        firstname, lastname = user.profile.name.split()
+
+        # add user to the survey
+        payload = {
+            "method": "add_participants",
+            "params": [
+                self.access_key,
+                self.survey_id,
+                [
+                    {
+                        "email": user.email,
+                        "lastname": lastname,
+                        "firstname": firstname,
+                        "attribute_1": anonymous_user_id,
+                    }
+                ]
+            ],
+            "id": 1,
+        }
+
+        # TO-DO: avoid duplicate user in the survey
+        requests.post(settings.LIMESURVEY_INTERNAL_API, json=payload).json()
+
+        # Get the access code for the user
+        payload = {
+            "method": "get_participant_properties",
+            "params": [
+                self.access_key,
+                self.survey_id,
+                {"attribute_1": anonymous_user_id},
+            ],
+            "id": 1,
+        }
+
+        response = requests.post(settings.LIMESURVEY_INTERNAL_API, json=payload).json()
+        self.access_code = response["result"]["token"]
 
         return {"survey_url": self.survey_url, "access_code": self.access_code}
 


### PR DESCRIPTION
### Description
This PR fixes the bug that allowed a student to be added multiple times to the same survey.

### How to test
1. Configure a survey as in [this PR](https://github.com/eduNEXT/xblock-limesurvey/pull/3).
2. In Studio add or edit the unit with the XBlock, and edit the configuration changing the Access key for API authentication and Survey ID.
3. From the LMS access to the unit with the XBlock
4. Verify that the student was added as a participant in the survey.
     ![image](https://github.com/eduNEXT/xblock-limesurvey/assets/64033729/4de834ed-242f-4bad-b5ea-7b892f2c7693)
5. Access the unit again.
6. Verify again the participants list in the survey. The student shouldn't be duplicated.