### PR TITLE
feat: add timeout in django settings

### DIFF
--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -58,12 +58,6 @@ class LimeSurveyXBlock(XBlock):
         help="The error message to display to the user",
     )
 
-    timeout = Integer(
-        default=5,
-        scope=Scope.settings,
-        help="Timeout for LimeSurvey API requests",
-    )
-
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
         data = pkg_resources.resource_string(__name__, path)
@@ -139,7 +133,6 @@ class LimeSurveyXBlock(XBlock):
                 access_key=self.access_key,
                 survey_id=self.survey_id,
                 display_name=self.display_name,
-                timeout=self.timeout,
             ),
         )
         frag.add_css(self.resource_string("static/css/limesurvey.css"))
@@ -161,7 +154,6 @@ class LimeSurveyXBlock(XBlock):
         self.display_name = data.get("display_name")
         self.access_key = data.get("access_key")
         self.survey_id = data.get("survey_id")
-        self.timeout = data.get("timeout")
 
         return {
             "result": "success",
@@ -291,7 +283,9 @@ class LimeSurveyXBlock(XBlock):
         }
 
         response = requests.post(
-            url=limesurvey_api_url, json=payload, timeout=self.timeout
+            url=limesurvey_api_url,
+            json=payload,
+            timeout=settings.LIMESURVEY_API_TIMEOUT,
         )
 
         if not response.ok:

--- a/limesurvey/settings/common.py
+++ b/limesurvey/settings/common.py
@@ -9,3 +9,5 @@ def plugin_settings(settings):
     Read / Update necessary project settings.
     """
     settings.MAKO_TEMPLATE_DIRS_BASE.append(LIMESURVEY_ROOT_DIRECTORY / "templates")
+    # Timeout configured to 5s as the average timeout for regular HTTP request
+    settings.LIMESURVEY_API_TIMEOUT = 5

--- a/limesurvey/static/html/limesurvey_edit.html
+++ b/limesurvey/static/html/limesurvey_edit.html
@@ -14,12 +14,6 @@
     </li>
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="limesurvey_timeout">API Timeout</label>
-        <input class="input setting-input" name="limesurvey_timeout" id="limesurvey_timeout" value="{timeout}" type="text" />
-      </div>
-    </li>
-    <li class="field comp-setting-entry is-set">
-      <div class="wrapper-comp-setting">
         <label class="label setting-label" for="limesurvey_survey_id">Survey ID</label>
         <input class="input setting-input" name="limesurvey_survey_id" id="limesurvey_survey_id" value="{survey_id}" type="text" />
       </div>

--- a/limesurvey/static/js/src/limesurveyEdit.js
+++ b/limesurvey/static/js/src/limesurveyEdit.js
@@ -7,7 +7,6 @@ function LimeSurveyXBlock(runtime, element) {
             display_name: $(element).find('input[name=limesurvey_display_name]').val(),
             access_key: $(element).find('input[name=limesurvey_access_key]').val(),
             survey_id: $(element).find('input[name=limesurvey_survey_id]').val(),
-            timeout: $(element).find('input[name=limesurvey_timeout]').val(),
         };
         $.post(handlerUrl, JSON.stringify(data)).done(function(response) {
           window.location.reload(false);


### PR DESCRIPTION
### Description
This PR adds the timeout of request in the LimeSurvey API as a django setting.

### How to test
1. Configure a survey as in [this PR](https://github.com/eduNEXT/xblock-limesurvey/pull/3).
2. In Studio add or edit the unit with the XBlock, and edit the configuration changing the Access key for API authentication and Survey ID.
3. From the LMS access to the unit with the XBlock.
4. The survey should load normally.

