### PR TITLE
fix: remove _invoke method after setting session key

### DIFF
--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -311,7 +311,6 @@ class LimeSurveyXBlock(XBlock):
             self.set_session_key()
             # Pop session key to avoid infinite recursion
             params.pop(0)
-            return self._invoke(method, *params)
 
         if result.get("status") not in ("OK", None):
             self.error_message = json_response.get("result").get("status")


### PR DESCRIPTION
## Description
This PR removes calling the _invoke method after setting the session key since it raised a max recursion error:

```
htly_edues-lms-1  | 2023-06-22 22:01:33,450 ERROR 31 [django.request] [user None] [ip None] log.py:224 - Internal Server Error: /xblock/block-v1:edX+limesurvey-1+2023+type@vertical+block@89ace6bc42f5457e9e59fc908459c5dc
tutor_dev_nightly_edues-lms-1  | Traceback (most recent call last):
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
tutor_dev_nightly_edues-lms-1  |     response = get_response(request)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
tutor_dev_nightly_edues-lms-1  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/http.py", line 40, in inner
tutor_dev_nightly_edues-lms-1  |     return func(request, *args, **kwargs)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/edx-platform/common/djangoapps/util/views.py", line 63, in inner
tutor_dev_nightly_edues-lms-1  |     response = view_func(request, *args, **kwargs)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/django/views/decorators/clickjacking.py", line 50, in wrapped_view
tutor_dev_nightly_edues-lms-1  |     resp = view_func(*args, **kwargs)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
tutor_dev_nightly_edues-lms-1  |     response = view_func(request, *args, **kwargs)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/edx-platform/lms/djangoapps/courseware/views/views.py", line 1629, in render_xblock
tutor_dev_nightly_edues-lms-1  |     fragment = block.render(requested_view, context=student_view_context)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/xblock/core.py", line 198, in render
tutor_dev_nightly_edues-lms-1  |     return self.runtime.render(self, view, context)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/edx-platform/xmodule/x_module.py", line 1033, in render
tutor_dev_nightly_edues-lms-1  |     return super().render(block, view_name, context=context)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/xblock/runtime.py", line 847, in render
tutor_dev_nightly_edues-lms-1  |     frag = view_fn(context)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/edx-platform/xmodule/vertical_block.py", line 202, in student_view
tutor_dev_nightly_edues-lms-1  |     return self._student_or_public_view(context, STUDENT_VIEW)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/edx-platform/xmodule/vertical_block.py", line 130, in _student_or_public_view
tutor_dev_nightly_edues-lms-1  |     rendered_child = child.render(view, child_block_context)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/xblock/core.py", line 198, in render
tutor_dev_nightly_edues-lms-1  |     return self.runtime.render(self, view, context)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/edx-platform/xmodule/x_module.py", line 1033, in render
tutor_dev_nightly_edues-lms-1  |     return super().render(block, view_name, context=context)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/xblock/runtime.py", line 847, in render
tutor_dev_nightly_edues-lms-1  |     frag = view_fn(context)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/requirements/xblock-limesurvey/limesurvey/limesurvey.py", line 107, in student_view
tutor_dev_nightly_edues-lms-1  |     if not self.user_in_survey(anonymous_user_id):
tutor_dev_nightly_edues-lms-1  |   File "/openedx/requirements/xblock-limesurvey/limesurvey/limesurvey.py", line 192, in user_in_survey
tutor_dev_nightly_edues-lms-1  |     response = self._invoke("list_participants", *params.values())
tutor_dev_nightly_edues-lms-1  |   File "/openedx/requirements/xblock-limesurvey/limesurvey/limesurvey.py", line 314, in _invoke
tutor_dev_nightly_edues-lms-1  |     return self._invoke(method, *params)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/requirements/xblock-limesurvey/limesurvey/limesurvey.py", line 314, in _invoke
tutor_dev_nightly_edues-lms-1  |     return self._invoke(method, *params)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/requirements/xblock-limesurvey/limesurvey/limesurvey.py", line 314, in _invoke
tutor_dev_nightly_edues-lms-1  |     return self._invoke(method, *params)
tutor_dev_nightly_edues-lms-1  |   [Previous line repeated 786 more times]
tutor_dev_nightly_edues-lms-1  |   File "/openedx/requirements/xblock-limesurvey/limesurvey/limesurvey.py", line 311, in _invoke
tutor_dev_nightly_edues-lms-1  |     self.set_session_key()
tutor_dev_nightly_edues-lms-1  |   File "/openedx/requirements/xblock-limesurvey/limesurvey/limesurvey.py", line 262, in set_session_key
tutor_dev_nightly_edues-lms-1  |     response = self._invoke(
tutor_dev_nightly_edues-lms-1  |   File "/openedx/requirements/xblock-limesurvey/limesurvey/limesurvey.py", line 293, in _invoke
tutor_dev_nightly_edues-lms-1  |     response = requests.post(
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/requests/api.py", line 115, in post
tutor_dev_nightly_edues-lms-1  |     return request("post", url, data=data, json=json, **kwargs)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/requests/api.py", line 59, in request
tutor_dev_nightly_edues-lms-1  |     return session.request(method=method, url=url, **kwargs)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/requests/sessions.py", line 589, in request
tutor_dev_nightly_edues-lms-1  |     resp = self.send(prep, **send_kwargs)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/requests/sessions.py", line 703, in send
tutor_dev_nightly_edues-lms-1  |     r = adapter.send(request, **kwargs)
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/requests/adapters.py", line 486, in send
tutor_dev_nightly_edues-lms-1  |     resp = conn.urlopen(
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 714, in urlopen
tutor_dev_nightly_edues-lms-1  |     httplib_response = self._make_request(
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 466, in _make_request
tutor_dev_nightly_edues-lms-1  |     six.raise_from(e, None)
tutor_dev_nightly_edues-lms-1  |   File "<string>", line 3, in raise_from
tutor_dev_nightly_edues-lms-1  |   File "/openedx/venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 461, in _make_request
tutor_dev_nightly_edues-lms-1  |     httplib_response = conn.getresponse()
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/http/client.py", line 1348, in getresponse
tutor_dev_nightly_edues-lms-1  |     response.begin()
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/http/client.py", line 335, in begin
tutor_dev_nightly_edues-lms-1  |     self.headers = self.msg = parse_headers(self.fp)
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/http/client.py", line 234, in parse_headers
tutor_dev_nightly_edues-lms-1  |     return email.parser.Parser(_class=_class).parsestr(hstring)
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/parser.py", line 67, in parsestr
tutor_dev_nightly_edues-lms-1  |     return self.parse(StringIO(text), headersonly=headersonly)
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/parser.py", line 56, in parse
tutor_dev_nightly_edues-lms-1  |     feedparser.feed(data)
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/feedparser.py", line 176, in feed
tutor_dev_nightly_edues-lms-1  |     self._call_parse()
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/feedparser.py", line 180, in _call_parse
tutor_dev_nightly_edues-lms-1  |     self._parse()
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/feedparser.py", line 295, in _parsegen
tutor_dev_nightly_edues-lms-1  |     if self._cur.get_content_maintype() == 'message':
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/message.py", line 594, in get_content_maintype
tutor_dev_nightly_edues-lms-1  |     ctype = self.get_content_type()
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/message.py", line 578, in get_content_type
tutor_dev_nightly_edues-lms-1  |     value = self.get('content-type', missing)
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/message.py", line 471, in get
tutor_dev_nightly_edues-lms-1  |     return self.policy.header_fetch_parse(k, v)
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/_policybase.py", line 316, in header_fetch_parse
tutor_dev_nightly_edues-lms-1  |     return self._sanitize_header(name, value)
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/_policybase.py", line 287, in _sanitize_header
tutor_dev_nightly_edues-lms-1  |     if _has_surrogates(value):
tutor_dev_nightly_edues-lms-1  |   File "/opt/pyenv/versions/3.8.15/lib/python3.8/email/utils.py", line 57, in _has_surrogates
tutor_dev_nightly_edues-lms-1  |     s.encode()
tutor_dev_nightly_edues-lms-1  | RecursionError: maximum recursion depth exceeded while calling a Python object
```