### PR TITLE
feat: add limesurvey admin iframe in instructor dashboard

### DIFF
--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -318,17 +318,13 @@ class LimeSurveyXBlock(XBlock):
 
         return json_response
 
-    def instructor_view(self, context=None):  # pylint: disable=unused-argument
+    def instructor_view(self, _context=None):
         """
         The studio view of the LimeSurveyXBlock, shown to instructors.
         """
         html = self.resource_string("static/html/instructor.html")
-        frag = Fragment(
-            html.format(
-                message="Hello instructor!",
-            ),
-        )
-        frag.add_css(self.resource_string("static/css/limesurvey.css"))
+        frag = Fragment(html.format(limesurvey_url=settings.LIMESURVEY_URL))
+        frag.add_css(self.resource_string("static/css/instructor.css"))
 
         # Add i18n js
         statici18n_js_url = self._get_statici18n_js_url()

--- a/limesurvey/static/css/instructor.css
+++ b/limesurvey/static/css/instructor.css
@@ -1,0 +1,13 @@
+.limesurvey-instructor-wrapper {
+    position: relative;
+    width: 100%;
+    padding-bottom: 56.25%;
+}
+
+.limesurvey-instructor-wrapper iframe {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+}

--- a/limesurvey/static/html/instructor.html
+++ b/limesurvey/static/html/instructor.html
@@ -1,4 +1,3 @@
-<div>
-    <p>LimeSurvey Instructor view</p>
-    <div> {{message}} </div>
+<div class="limesurvey-instructor-wrapper">
+    <iframe class="limesurvey-admin-iframe" src="{limesurvey_url}/admin" frameborder="0"></iframe>
 </div>


### PR DESCRIPTION
### Description
- This PR adds the administrator of LimeSurvey into the instructor dashboard.

### How to test
1. Add the LimeSurvey tab to the instructor dashboard by following instructions in [this PR](https://github.com/eduNEXT/xblock-limesurvey/pull/8).
2. Finally, go to the instructor dashboard with the proper permissions (as an instructor of the course). You'll see:
![image](https://github.com/eduNEXT/xblock-limesurvey/assets/64033729/0303711c-1767-4e95-abb0-ff027aacc3b5)