### PR TITLE
refactor!: modify xblock implementation for better workflow

### DIFF
--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -357,7 +357,11 @@ class LimeSurveyXBlock(XBlock):
 
         current_time = datetime.now().replace(tzinfo=pytz.utc)
         login_attempts_exceeded = self.last_login_attempt and \
-        self.last_login_attempt > current_time - timedelta(minutes=getattr(settings, "LIMESURVEY_LOGIN_ATTEMPTS_TIMEOUT", 5))
+        self.last_login_attempt > current_time - timedelta(
+            minutes=getattr(
+                settings, "LIMESURVEY_LOGIN_ATTEMPTS_TIMEOUT", 5,
+            )
+        )
         if login_attempts_exceeded:
             raise ExceededLoginAttempts
         self.last_login_attempt = datetime.now()

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -145,7 +145,7 @@ class LimeSurveyXBlock(XBlock):
         context = {
             "self": self,
             "show_survey": show_survey,
-            error_message: error_message,
+            "error_message": error_message,
         }
         html = self.render_template("static/html/limesurvey.html", context)
         frag = Fragment(html)

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -122,9 +122,10 @@ class LimeSurveyXBlock(XBlock):
         """
         Setup LimeSurvey configurations for the student view of the XBlock.
         """
+        self.survey_url = f"{settings.LIMESURVEY_URL}/{self.survey_id}"
         self.set_session_key()
+        self.set_student_access_code(anonymous_user_id)
         self.add_participant_to_survey(user, anonymous_user_id)
-        self.set_survey_info(anonymous_user_id)
 
     def student_view(self, show_survey):
         """
@@ -198,8 +199,7 @@ class LimeSurveyXBlock(XBlock):
         args:
             anonymous_user_id (str): The anonymous user ID of the user
         """
-        self.survey_url = f"{settings.LIMESURVEY_URL}/{self.survey_id}"
-        self.access_code = self.get_student_access_code(anonymous_user_id)
+
 
     def get_survey_summary(self) -> dict:
         """
@@ -244,7 +244,7 @@ class LimeSurveyXBlock(XBlock):
 
         return False
 
-    def get_student_access_code(self, anonymous_user_id) -> str:
+    def set_student_access_code(self, anonymous_user_id) -> str:
         """
         Return the access code for the current user.
 
@@ -260,7 +260,7 @@ class LimeSurveyXBlock(XBlock):
             {"attribute_1": anonymous_user_id}
         )
 
-        return response.get("token", "")
+        self.access_code = response.get("token", "")
 
     @staticmethod
     def get_fullname(user) -> Tuple[str, str]:

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -311,7 +311,6 @@ class LimeSurveyXBlock(XBlock):
             self.set_session_key()
             # Pop session key to avoid infinite recursion
             params.pop(0)
-            return self._invoke(method, *params)
 
         if result.get("status") not in ("OK", None):
             self.error_message = json_response.get("result").get("status")

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -140,7 +140,7 @@ class LimeSurveyXBlock(XBlock):
         if show_survey:
             try:
                 self.setup_student_view_survey(user, anonymous_user_id)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 error_message = str(e)
 
         context = {
@@ -294,7 +294,7 @@ class LimeSurveyXBlock(XBlock):
         """
         try:
             self.check_user_in_survey(anonymous_user_id)
-            return
+            return None
         except NoParticipantFound:
             pass
 
@@ -321,7 +321,8 @@ class LimeSurveyXBlock(XBlock):
             pass
 
         current_time = datetime.now().replace(tzinfo=pytz.utc)
-        login_attempts_exceeded = self.last_login_attempt and self.last_login_attempt > current_time - timedelta(minutes=1)
+        login_attempts_exceeded = self.last_login_attempt and \
+        self.last_login_attempt > current_time - timedelta(minutes=1)
         if login_attempts_exceeded:
             raise ExceededLoginAttempts("""Login attempts exceeded. Please wait a few minutes minutes and try again.""")
         self.last_login_attempt = datetime.now()

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -236,15 +236,6 @@ class LimeSurveyXBlock(XBlock):
             "result": "success",
         }
 
-    def set_survey_info(self, anonymous_user_id: str):
-        """
-        Set current survey information like URL and current student access code for it.
-
-        args:
-            anonymous_user_id (str): The anonymous user ID of the user
-        """
-
-
     def get_survey_summary(self) -> dict:
         """
         Get the summary of the current configured survey.

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -124,8 +124,8 @@ class LimeSurveyXBlock(XBlock):
         """
         self.survey_url = f"{settings.LIMESURVEY_URL}/{self.survey_id}"
         self.set_session_key()
-        self.set_student_access_code(anonymous_user_id)
         self.add_participant_to_survey(user, anonymous_user_id)
+        self.set_student_access_code(anonymous_user_id)
 
     def student_view(self, show_survey):
         """

--- a/limesurvey/static/html/limesurvey.html
+++ b/limesurvey/static/html/limesurvey.html
@@ -1,7 +1,7 @@
 {% if show_survey %}
 <div class="limesurvey-xblock-wrapper">
-    {% if self.error_message %}
-    <p>The survey can't be rendered due to the following error: <b>{{self.error_message}}</b></p>
+    {% if error_message %}
+    <p>The survey can't be rendered due to the following error: <b>{{error_message}}</b></p>
     <p>Please contact the instructor.</p>
     {% else %}
     <iframe class="survey-iframe" src="{{ self.survey_url }}?token={{ self.access_code }}" frameborder="0"></iframe>

--- a/limesurvey/static/html/limesurvey.html
+++ b/limesurvey/static/html/limesurvey.html
@@ -2,7 +2,7 @@
 <div class="limesurvey-xblock-wrapper">
     {% if error_message %}
     <p>The survey can't be rendered due to the following error: <b>{{error_message}}</b></p>
-    <p>Please contact the instructor.</p>
+    <p>Please contact the instructor or an administrator.</p>
     {% else %}
     <iframe class="survey-iframe" src="{{ self.survey_url }}?token={{ self.access_code }}" frameborder="0"></iframe>
     {% endif %}


### PR DESCRIPTION
[refactor!: modify xblock implementation for better workflow](https://github.com/eduNEXT/xblock-limesurvey/pull/17/commits/9fbfec16c2e959ccfc03c4504758bc76d762fb1d)

- Centralize defining error messages in the view that renders it
- Raise exceptions when getting an error instead of saving the
message
- Add check if participant is already in survey inside add participant
method
- Check if session key is still valid before getting a new one
- Check the last time a session key was retrieved
- Return response dictionary result instead of json_response so we
get the response without having to always run: response.get("result")
- Create custom exceptions for known API errors, so they can be
correctly handled