### PR TITLE
fix: return if there is no limesurvey block in the course

### DIFF
--- a/limesurvey/extensions/filters.py
+++ b/limesurvey/extensions/filters.py
@@ -29,7 +29,14 @@ class AddInstructorLimesurveyTab(PipelineStep):
         limesurvey_blocks = modulestore().get_items(
             course.id, qualifiers={"category": LIMESURVEY_BLOCK_CATEGORY}
         )
-        limesurvey_block = limesurvey_blocks[0]
+        limesurvey_block = None
+        if len(limesurvey_blocks) > 0:
+            limesurvey_block = limesurvey_blocks[0]
+
+        # Return if there is no LimeSurvey block in the course
+        if not limesurvey_block:
+            return context
+
         block, __ = get_block_by_usage_id(
             request, str(course.id), str(limesurvey_block.location),
             disable_staff_debug_info=True, course=course


### PR DESCRIPTION
## Description
Return without modifying the instructor dashboard when there is no limesurvey block specified.

## How to test
1. Install limesurvey xblock but don't add it to the course
2. Navigate your course as an instructor. The pages should render normally.