### PR TITLE
refactor: use import backends to handle multiple source code versions

### DIFF
--- a/limesurvey/edxapp_wrapper/backends/courseware_o_v1.py
+++ b/limesurvey/edxapp_wrapper/backends/courseware_o_v1.py
@@ -1,0 +1,28 @@
+"""
+Courseware definitions for Open edX Olive release.
+"""
+from lms.djangoapps.courseware.module_render import get_module_by_usage_id
+
+
+def get_object_by_usage_id(request, course_id, location, disable_staff_debug_info=False, course=None):
+    """
+    Get the block object for the given block usage id.
+
+    Args:
+        request (HttpRequest): Django request object.
+        course_id (str): Course ID.
+        location (str): block location.
+        disable_staff_debug_info (bool): Whether to disable staff debug info.
+        course (CourseDescriptor): Course descriptor.
+
+    Returns:
+        BlockUsageLocator: Block object.
+    """
+    block, __ = get_module_by_usage_id(
+        request,
+        course_id,
+        location,
+        disable_staff_debug_info=disable_staff_debug_info,
+        course=course,
+    )
+    return block

--- a/limesurvey/edxapp_wrapper/backends/courseware_p_v1.py
+++ b/limesurvey/edxapp_wrapper/backends/courseware_p_v1.py
@@ -1,0 +1,28 @@
+"""
+Courseware definitions for Open edX Palm release.
+"""
+from lms.djangoapps.courseware.block_render import get_block_by_usage_id
+
+
+def get_object_by_usage_id(request, course_id, location, disable_staff_debug_info=False, course=None):
+    """
+    Get the block object for the given block usage id.
+
+    Args:
+        request (HttpRequest): Django request object.
+        course_id (str): Course ID.
+        location (str): block location.
+        disable_staff_debug_info (bool): Whether to disable staff debug info.
+        course (CourseDescriptor): Course descriptor.
+
+    Returns:
+        BlockUsageLocator: Block object.
+    """
+    block, __ = get_block_by_usage_id(
+        request,
+        course_id,
+        location,
+        disable_staff_debug_info=disable_staff_debug_info,
+        course=course,
+    )
+    return block

--- a/limesurvey/edxapp_wrapper/backends/xmodule_p_v1.py
+++ b/limesurvey/edxapp_wrapper/backends/xmodule_p_v1.py
@@ -1,0 +1,10 @@
+"""
+Xmodule definitions for Open edX Palm release.
+"""
+from xmodule.modulestore.django import modulestore
+
+def get_modulestore(*args, **kwargs):
+    """
+    Get the modulestore object.
+    """
+    return modulestore(*args, **kwargs)

--- a/limesurvey/edxapp_wrapper/courseware.py
+++ b/limesurvey/edxapp_wrapper/courseware.py
@@ -15,4 +15,4 @@ def get_object_by_usage_id_function(*args, **kwargs):
     return backend.get_object_by_usage_id(*args, **kwargs)
 
 
-get_object_by_usage_id = get_object_by_usage_id_function()
+get_object_by_usage_id = get_object_by_usage_id_function

--- a/limesurvey/edxapp_wrapper/courseware.py
+++ b/limesurvey/edxapp_wrapper/courseware.py
@@ -1,0 +1,18 @@
+"""
+Courseware generalized definitions.
+"""
+
+from importlib import import_module
+from django.conf import settings
+
+
+def get_object_by_usage_id_function(*args, **kwargs):
+    """Get the block object for the given block usage id."""
+
+    backend_function = settings.LIMESURVEY_COURSEWARE_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_object_by_usage_id(*args, **kwargs)
+
+
+get_object_by_usage_id = get_object_by_usage_id_function()

--- a/limesurvey/edxapp_wrapper/xmodule.py
+++ b/limesurvey/edxapp_wrapper/xmodule.py
@@ -1,0 +1,18 @@
+"""
+Xmodule generalized definitions.
+"""
+
+from importlib import import_module
+from django.conf import settings
+
+
+def get_modulestore_function(*args, **kwargs):
+    """Get modulestore object."""
+
+    backend_function = settings.LIMESURVEY_XMODULE_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_modulestore(*args, **kwargs)
+
+
+modulestore = get_modulestore_function()

--- a/limesurvey/edxapp_wrapper/xmodule.py
+++ b/limesurvey/edxapp_wrapper/xmodule.py
@@ -15,4 +15,4 @@ def get_modulestore_function(*args, **kwargs):
     return backend.get_modulestore(*args, **kwargs)
 
 
-modulestore = get_modulestore_function()
+modulestore = get_modulestore_function

--- a/limesurvey/extensions/filters.py
+++ b/limesurvey/extensions/filters.py
@@ -4,12 +4,8 @@ Open edX Filters needed for LimeSurvey integration.
 from crum import get_current_request
 from openedx_filters import PipelineStep
 
-try:
-    from xmodule.modulestore.django import modulestore
-    from lms.djangoapps.courseware.block_render import get_block_by_usage_id
-except ImportError:
-    modulestore = object
-    get_block_by_usage_id = object
+from limesurvey.edxapp_wrapper.courseware import get_object_by_usage_id
+from limesurvey.edxapp_wrapper.xmodule import modulestore
 
 INSTRUCTOR_TEMPLATE_ABSOLUTE_PATH = "/instructor_dashboard/"
 LIMESURVEY_BLOCK_CATEGORY = "limesurvey"
@@ -37,7 +33,7 @@ class AddInstructorLimesurveyTab(PipelineStep):
         if not limesurvey_block:
             return context
 
-        block, __ = get_block_by_usage_id(
+        block = get_object_by_usage_id(
             request, str(course.id), str(limesurvey_block.location),
             disable_staff_debug_info=True, course=course
         )

--- a/limesurvey/settings/common.py
+++ b/limesurvey/settings/common.py
@@ -13,3 +13,7 @@ def plugin_settings(settings):
     settings.LIMESURVEY_API_TIMEOUT = 5
     settings.LIMESURVEY_API_USER = "CHANGE-ME"
     settings.LIMESURVEY_API_PASSWORD = "CHANGE-ME"
+
+    # Limesurvey backend settings
+    settings.LIMESURVEY_COURSEWARE_BACKEND = "limesurvey.edxapp_wrapper.backend.courseware_p_v1"
+    settings.LIMESURVEY_XMODULE_BACKEND = "limesurvey.edxapp_wrapper.backend.xmodule_p_v1"

--- a/limesurvey/settings/common.py
+++ b/limesurvey/settings/common.py
@@ -15,5 +15,5 @@ def plugin_settings(settings):
     settings.LIMESURVEY_API_PASSWORD = "CHANGE-ME"
 
     # Limesurvey backend settings
-    settings.LIMESURVEY_COURSEWARE_BACKEND = "limesurvey.edxapp_wrapper.backend.courseware_p_v1"
-    settings.LIMESURVEY_XMODULE_BACKEND = "limesurvey.edxapp_wrapper.backend.xmodule_p_v1"
+    settings.LIMESURVEY_COURSEWARE_BACKEND = "limesurvey.edxapp_wrapper.backends.courseware_p_v1"
+    settings.LIMESURVEY_XMODULE_BACKEND = "limesurvey.edxapp_wrapper.backends.xmodule_p_v1"

--- a/limesurvey/settings/production.py
+++ b/limesurvey/settings/production.py
@@ -22,3 +22,13 @@ def plugin_settings(settings):
         "LIMESURVEY_API_PASSWORD",
         settings.LIMESURVEY_API_PASSWORD
     )
+
+    # Limesurvey backend settings
+    settings.LIMESURVEY_COURSEWARE_BACKEND = getattr(settings, "ENV_TOKENS", {}).get(
+        "LIMESURVEY_COURSEWARE_BACKEND",
+        settings.LIMESURVEY_COURSEWARE_BACKEND
+    )
+    settings.LIMESURVEY_XMODULE_BACKEND = getattr(settings, "ENV_TOKENS", {}).get(
+        "LIMESURVEY_XMODULE_BACKEND",
+        settings.LIMESURVEY_XMODULE_BACKEND
+    )

--- a/limesurvey/settings/test.py
+++ b/limesurvey/settings/test.py
@@ -55,5 +55,5 @@ LIMESURVEY_URL = "https://test-url.com"
 LIMESURVEY_INTERNAL_API = "https://test-url.com/index.php/admin/remotecontrol"
 
 # Limesurvey backend settings
-LIMESURVEY_COURSEWARE_BACKEND = "limesurvey.edxapp_wrapper.backend.courseware_p_v1"
-LIMESURVEY_XMODULE_BACKEND = "limesurvey.edxapp_wrapper.backend.xmodule_p_v1"
+LIMESURVEY_COURSEWARE_BACKEND = "limesurvey.edxapp_wrapper.backends.courseware_p_v1"
+LIMESURVEY_XMODULE_BACKEND = "limesurvey.edxapp_wrapper.backends.xmodule_p_v1"

--- a/limesurvey/settings/test.py
+++ b/limesurvey/settings/test.py
@@ -53,3 +53,7 @@ LIMESURVEY_URL = "https://test-url.com"
 
 # LimeSurvey internal survey URL
 LIMESURVEY_INTERNAL_API = "https://test-url.com/index.php/admin/remotecontrol"
+
+# Limesurvey backend settings
+LIMESURVEY_COURSEWARE_BACKEND = "limesurvey.edxapp_wrapper.backend.courseware_p_v1"
+LIMESURVEY_XMODULE_BACKEND = "limesurvey.edxapp_wrapper.backend.xmodule_p_v1"


### PR DESCRIPTION
### Description
This PR adds backends to import code from different Open edX versions. This is how it happens:

We configure a backend that supports importing code from a specific Open edX version, for example: 

`LIMESURVEY_COURSEWARE_BACKEND = "limesurvey.edxapp_wrapper.backend.courseware_p_v1"`

Allowing us to import code from the Palm release (since the _p_ in the name).

Then, during runtime, we import the methods we need in our implementation from the module `limesurvey/edxapp_wrapper/courseware`, which loads the correct module (the versioned one) we configured through that setting. The versioned module,  exports the according function we need:

`get_object_by_usage_id = get_object_by_usage_id_function()`

If we need to use the plugin in another version, we just change the configuration. This approach is needed since in Olive the function `get_block_by_usage_id` is actually called `get_module_by_usage_id`, so we need to make the distinction.

This approach is broadly used by eduNEXT in its projects, check-out: eox-core, eox-tagging, and so on for more examples.

### How to test
Install the new version in your Palm installation and checkout it's working as before.