### PR TITLE
fix: use different admin endpoint for instructors

### DIFF
--- a/limesurvey/static/html/instructor.html
+++ b/limesurvey/static/html/instructor.html
@@ -1,3 +1,3 @@
 <div class="limesurvey-instructor-wrapper">
-    <iframe class="limesurvey-admin-iframe" src="{{limesurvey_url}}/admin" frameborder="0"></iframe>
+    <iframe class="limesurvey-admin-iframe" src="{{limesurvey_url}}/admin/" frameborder="0"></iframe>
 </div>


### PR DESCRIPTION
## Description
This PR changes what to render in the instructor's view since LimeSurvey enforces absolutes paths. This way, we can avoid the first 301 redirections from `/admin` to `/admin/` with an incorrect URL scheme.

## How to test
Try entering the instructor view of the xblock, it should work exactly the same. You can check the redirections I mentioned before by running:

```
curl -Ik https://limesurvey.subdomain/admin/
curl -Ik https://limesurvey.subdomain/admin
```