### PR TITLE
feat: add limesurvey url in xblock settings

### DIFF
--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -116,6 +116,12 @@ class LimeSurveyXBlock(XBlock):
         help="The ID of the survey to be embedded",
     )
 
+    limesurvey_url = String(
+        display_name="LimeSurvey URL",
+        default=None,
+        scope=Scope.settings
+    )
+
     session_key = String(
         default=None,
         scope=Scope.user_state_summary,
@@ -181,7 +187,7 @@ class LimeSurveyXBlock(XBlock):
         """
         Setup LimeSurvey configurations for the student view of the XBlock.
         """
-        limesurvey_url = getattr(settings, "LIMESURVEY_URL", None)
+        limesurvey_url = self.limesurvey_url or getattr(settings, "LIMESURVEY_URL", None)
         if not limesurvey_url:
             raise MisconfiguredLimeSurveyService("LIMESURVEY_URL is not set in your service configurations.")
 
@@ -229,7 +235,11 @@ class LimeSurveyXBlock(XBlock):
         """
         The studio view of the LimeSurveyXBlock, shown to instructors.
         """
-        context = {"survey_id": self.survey_id, "display_name": self.display_name}
+        context = {
+            "survey_id": self.survey_id,
+            "display_name": self.display_name,
+            "limesurvey_url": self.limesurvey_url
+        }
         html = self.render_template("static/html/limesurvey_edit.html", context)
         frag = Fragment(html)
         frag.add_css(self.resource_string("static/css/limesurvey.css"))
@@ -250,6 +260,7 @@ class LimeSurveyXBlock(XBlock):
         """
         self.display_name = data.get("display_name")
         self.survey_id = data.get("survey_id")
+        self.limesurvey_url = data.get("limesurvey_url")
 
     def get_survey_summary(self) -> dict:
         """

--- a/limesurvey/static/html/limesurvey_edit.html
+++ b/limesurvey/static/html/limesurvey_edit.html
@@ -12,6 +12,12 @@
         <input class="input setting-input" name="limesurvey_survey_id" id="limesurvey_survey_id" value="{{survey_id}}" type="text" />
       </div>
     </li>
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="limesurvey_url">LimeSurvey URL</label>
+        <input class="input setting-input" name="limesurvey_url" id="limesurvey_url" value="{{limesurvey_url}}" type="text" />
+      </div>
+    </li>
   </ul>
 
   <div class="xblock-actions">

--- a/limesurvey/static/js/src/limesurveyEdit.js
+++ b/limesurvey/static/js/src/limesurveyEdit.js
@@ -6,6 +6,7 @@ function LimeSurveyXBlock(runtime, element) {
         var data = {
             display_name: $(element).find('input[name=limesurvey_display_name]').val(),
             survey_id: $(element).find('input[name=limesurvey_survey_id]').val(),
+            limesurvey_url: $(element).find('input[name=limesurvey_url]').val(),
         };
         $.post(handlerUrl, JSON.stringify(data)).done(function(response) {
           window.location.reload(false);

--- a/limesurvey/tests/test_limesurvey.py
+++ b/limesurvey/tests/test_limesurvey.py
@@ -40,6 +40,7 @@ class TestLimeSurveyXBlock(TestCase):
         self.xblock.setup_student_view_survey = Mock()
         self.xblock.display_name = "Test LimeSurvey"
         self.xblock.survey_id = "test-survey-id"
+        self.xblock.limesurvey_url = "test-limesurvey-url"
 
     @patch("limesurvey.limesurvey.Fragment")
     def test_student_view_with_survey(self, _):
@@ -124,6 +125,7 @@ class TestLimeSurveyXBlock(TestCase):
         expected_context = {
             "survey_id": self.xblock.survey_id,
             "display_name": self.xblock.display_name,
+            "limesurvey_url": self.xblock.limesurvey_url,
         }
 
         self.xblock.studio_view()
@@ -409,6 +411,7 @@ class TestLimeSurveyUtilities(TestCase):
         """
         user = Mock()
         anonymous_user_id = "test-anonymous-user-id"
+        self.xblock.limesurvey_url = None
 
         with self.assertRaises(MisconfiguredLimeSurveyService):
             self.xblock.setup_student_view_survey(


### PR DESCRIPTION
### Description
This PR adds the LimeSurvey URL in the XBlock settings. This field is optional, so if the value is `None`, the URL will be the defined in the Tutor configuration.

### How to Test
1. Configure a survey as in [this PR](https://github.com/eduNEXT/xblock-limesurvey/pull/3).
2. In Studio edit the unit with the XBlock, and edit the configuration changing "LimeSurvey URL".
3. From the LMS access to the unit with the XBlock.
4. The URL of the iframe should be the configured in the XBlock settings.