### PR TITLE
 feat: add anonymous surveys support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Unreleased
 
 *
 
+0.3.0 – 2023-07-12
+**********************************************
+
+Added
+=====
+
+* Xblock support for anonymous surveys.
+* Support for multiple LimeSurvey instances per course.
+
 
 0.2.3 – 2023-07-06
 **********************************************

--- a/limesurvey/__init__.py
+++ b/limesurvey/__init__.py
@@ -5,6 +5,6 @@ import os
 from pathlib import Path
 from .limesurvey import LimeSurveyXBlock
 
-__version__ = '0.2.3'
+__version__ = '0.3.0'
 
 LIMESURVEY_ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -202,7 +202,6 @@ class LimeSurveyXBlock(XBlock):
 
         if not self.anonymous_survey:
             self.add_participant_to_survey(user, anonymous_user_id)
-        if not self.open_access_mode:
             self.set_student_access_code(anonymous_user_id)
 
     def student_view(self, show_survey):
@@ -249,10 +248,8 @@ class LimeSurveyXBlock(XBlock):
             "limesurvey_url": self.limesurvey_url,
             "survey_id": self.survey_id,
             "anonymous_survey": self.anonymous_survey,
-            "open_access_mode": self.open_access_mode,
             "survey_id_field": self.fields["survey_id"],
             "anonymous_survey_field": self.fields["anonymous_survey"],
-            "open_access_mode_field": self.fields["open_access_mode"],
         }
 
         html = self.render_template("static/html/limesurvey_edit.html", context)

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -15,7 +15,7 @@ from django.template import Context, Template
 from django.utils import translation
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
-from xblock.fields import DateTime, Integer, Scope, String
+from xblock.fields import DateTime, Integer, Scope, String, Boolean
 from xblockutils.resources import ResourceLoader
 
 log = logging.getLogger(__name__)
@@ -122,6 +122,12 @@ class LimeSurveyXBlock(XBlock):
         scope=Scope.settings
     )
 
+    anonymous_survey = Boolean(
+        default=False,
+        scope=Scope.settings,
+        help="Whether the survey is anonymous or not.",
+    )
+
     session_key = String(
         default=None,
         scope=Scope.user_state_summary,
@@ -193,8 +199,11 @@ class LimeSurveyXBlock(XBlock):
 
         self.survey_url = f"{limesurvey_url}/{self.survey_id}"
         self.set_session_key()
-        self.add_participant_to_survey(user, anonymous_user_id)
-        self.set_student_access_code(anonymous_user_id)
+
+        if not self.anonymous_survey:
+            self.add_participant_to_survey(user, anonymous_user_id)
+        if not self.open_access_mode:
+            self.set_student_access_code(anonymous_user_id)
 
     def student_view(self, show_survey):
         """
@@ -236,10 +245,16 @@ class LimeSurveyXBlock(XBlock):
         The studio view of the LimeSurveyXBlock, shown to instructors.
         """
         context = {
-            "survey_id": self.survey_id,
             "display_name": self.display_name,
-            "limesurvey_url": self.limesurvey_url
+            "limesurvey_url": self.limesurvey_url,
+            "survey_id": self.survey_id,
+            "anonymous_survey": self.anonymous_survey,
+            "open_access_mode": self.open_access_mode,
+            "survey_id_field": self.fields["survey_id"],
+            "anonymous_survey_field": self.fields["anonymous_survey"],
+            "open_access_mode_field": self.fields["open_access_mode"],
         }
+
         html = self.render_template("static/html/limesurvey_edit.html", context)
         frag = Fragment(html)
         frag.add_css(self.resource_string("static/css/limesurvey.css"))
@@ -261,6 +276,7 @@ class LimeSurveyXBlock(XBlock):
         self.display_name = data.get("display_name")
         self.survey_id = data.get("survey_id")
         self.limesurvey_url = data.get("limesurvey_url")
+        self.anonymous_survey = bool(data.get("anonymous_survey"))
 
     def get_survey_summary(self) -> dict:
         """

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -119,7 +119,8 @@ class LimeSurveyXBlock(XBlock):
     limesurvey_url = String(
         display_name="LimeSurvey URL",
         default=None,
-        scope=Scope.settings
+        scope=Scope.settings,
+        help="The URL of the LimeSurvey installation. If not set, it will be taken from the service configurations.",
     )
 
     anonymous_survey = Boolean(
@@ -137,7 +138,7 @@ class LimeSurveyXBlock(XBlock):
     survey_url = String(
         default=None,
         scope=Scope.user_state_summary,
-        help="The URL of the survey",
+        help="The URL of the survey for the current student.",
     )
 
     access_code = String(
@@ -250,6 +251,7 @@ class LimeSurveyXBlock(XBlock):
             "anonymous_survey": self.anonymous_survey,
             "survey_id_field": self.fields["survey_id"],
             "anonymous_survey_field": self.fields["anonymous_survey"],
+            "limesurvey_url_field": self.fields["limesurvey_url"],
         }
 
         html = self.render_template("static/html/limesurvey_edit.html", context)

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -118,9 +118,11 @@ class LimeSurveyXBlock(XBlock):
 
     limesurvey_url = String(
         display_name="LimeSurvey URL",
-        default=None,
+        default="",
         scope=Scope.settings,
-        help="The URL of the LimeSurvey installation. If not set, it will be taken from the service configurations.",
+        help="""
+        The URL of the LimeSurvey installation without the trailing slash.
+        If not set, it will be taken from the service configurations.""",
     )
 
     anonymous_survey = Boolean(

--- a/limesurvey/static/html/limesurvey.html
+++ b/limesurvey/static/html/limesurvey.html
@@ -3,8 +3,12 @@
     {% if error_message %}
     <p>The survey can't be rendered due to the following error: <b>{{error_message}}</b></p>
     <p>Please contact the instructor or an administrator.</p>
-    {% else %}
-    <iframe class="survey-iframe" src="{{ self.survey_url }}?token={{ self.access_code }}" frameborder="0"></iframe>
+    {% else %} 
+        {% if self.open_access_mode %}
+            <iframe class="survey-iframe" src="{{ self.survey_url }}" frameborder="0"></iframe>
+        {% else %}
+            <iframe class="survey-iframe" src="{{ self.survey_url }}?token={{ self.access_code }}" frameborder="0"></iframe>
+        {% endif %}
     {% endif %}
 </div>
 {% else %}

--- a/limesurvey/static/html/limesurvey.html
+++ b/limesurvey/static/html/limesurvey.html
@@ -1,10 +1,10 @@
 {% if show_survey %}
 <div class="limesurvey-xblock-wrapper">
     {% if error_message %}
-    <p>The survey can't be rendered due to the following error: <b>{{error_message}}</b></p>
-    <p>Please contact the instructor or an administrator.</p>
+        <p>The survey can't be rendered due to the following error: <b>{{error_message}}</b></p>
+        <p>Please contact the instructor or an administrator.</p>
     {% else %} 
-        {% if self.open_access_mode %}
+        {% if self.anonymous_survey %}
             <iframe class="survey-iframe" src="{{ self.survey_url }}" frameborder="0"></iframe>
         {% else %}
             <iframe class="survey-iframe" src="{{ self.survey_url }}?token={{ self.access_code }}" frameborder="0"></iframe>

--- a/limesurvey/static/html/limesurvey_edit.html
+++ b/limesurvey/static/html/limesurvey_edit.html
@@ -28,6 +28,7 @@
         <label class="label setting-label" for="limesurvey_url">LimeSurvey URL</label>
         <input class="input setting-input" name="limesurvey_url" id="limesurvey_url" value="{{limesurvey_url}}" type="text" />
       </div>
+      <span class="tip setting-help"> {{ limesurvey_url_field.help }} </span>
     </li>
   </ul>
 

--- a/limesurvey/static/html/limesurvey_edit.html
+++ b/limesurvey/static/html/limesurvey_edit.html
@@ -11,6 +11,27 @@
         <label class="label setting-label" for="limesurvey_survey_id">Survey ID</label>
         <input class="input setting-input" name="limesurvey_survey_id" id="limesurvey_survey_id" value="{{survey_id}}" type="text" />
       </div>
+      <span class="tip setting-help"> {{ survey_id_field.help }} </span>
+    </li>
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="limesurvey_anonymous_survey">Anonymous survey</label>
+        <select id="limesurvey_anonymous_survey" class="input setting-input" name="limesurvey_anonymous_survey" >
+            <option value=1 {% if anonymous_survey %} selected{% endif %}> True </option>
+            <option value=0 {% if not anonymous_survey %} selected{% endif %}> False </option>
+        </select>
+      </div>
+      <span class="tip setting-help"> {{ anonymous_survey_field.help }} </span>
+    </li>
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="limesurvey_open_access_mode">Open access mode</label>
+        <select id="limesurvey_open_access_mode" class="input setting-input" name="limesurvey_open_access_mode" >
+            <option value=1 {% if open_access_mode %} selected{% endif %}> True </option>
+            <option value=0 {% if not open_access_mode %} selected{% endif %}> False </option>
+        </select>
+      </div>
+      <span class="tip setting-help"> {{ open_access_mode_field.help }}  </span>
     </li>
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">

--- a/limesurvey/static/html/limesurvey_edit.html
+++ b/limesurvey/static/html/limesurvey_edit.html
@@ -25,16 +25,6 @@
     </li>
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="limesurvey_open_access_mode">Open access mode</label>
-        <select id="limesurvey_open_access_mode" class="input setting-input" name="limesurvey_open_access_mode" >
-            <option value=1 {% if open_access_mode %} selected{% endif %}> True </option>
-            <option value=0 {% if not open_access_mode %} selected{% endif %}> False </option>
-        </select>
-      </div>
-      <span class="tip setting-help"> {{ open_access_mode_field.help }}  </span>
-    </li>
-    <li class="field comp-setting-entry is-set">
-      <div class="wrapper-comp-setting">
         <label class="label setting-label" for="limesurvey_url">LimeSurvey URL</label>
         <input class="input setting-input" name="limesurvey_url" id="limesurvey_url" value="{{limesurvey_url}}" type="text" />
       </div>

--- a/limesurvey/static/js/src/limesurveyEdit.js
+++ b/limesurvey/static/js/src/limesurveyEdit.js
@@ -8,7 +8,6 @@ function LimeSurveyXBlock(runtime, element) {
             survey_id: $(element).find('input[name=limesurvey_survey_id]').val(),
             limesurvey_url: $(element).find('input[name=limesurvey_url]').val(),
             anonymous_survey: Number($(element).find('select[name=limesurvey_anonymous_survey]').val()),
-            open_access_mode: Number($(element).find('select[name=limesurvey_open_access_mode]').val()),
         };
         $.post(handlerUrl, JSON.stringify(data)).done(function(response) {
           window.location.reload(false);

--- a/limesurvey/static/js/src/limesurveyEdit.js
+++ b/limesurvey/static/js/src/limesurveyEdit.js
@@ -7,6 +7,8 @@ function LimeSurveyXBlock(runtime, element) {
             display_name: $(element).find('input[name=limesurvey_display_name]').val(),
             survey_id: $(element).find('input[name=limesurvey_survey_id]').val(),
             limesurvey_url: $(element).find('input[name=limesurvey_url]').val(),
+            anonymous_survey: Number($(element).find('select[name=limesurvey_anonymous_survey]').val()),
+            open_access_mode: Number($(element).find('select[name=limesurvey_open_access_mode]').val()),
         };
         $.post(handlerUrl, JSON.stringify(data)).done(function(response) {
           window.location.reload(false);

--- a/limesurvey/tests/test_limesurvey.py
+++ b/limesurvey/tests/test_limesurvey.py
@@ -127,6 +127,7 @@ class TestLimeSurveyXBlock(TestCase):
             "survey_id": "test-survey-id",
             "display_name": "Test LimeSurvey",
             "anonymous_survey": True,
+            "limesurvey_url": self.xblock.limesurvey_url,
         }
         expected_context = {
             "survey_id": self.xblock.survey_id,
@@ -135,6 +136,7 @@ class TestLimeSurveyXBlock(TestCase):
             "anonymous_survey": self.xblock.anonymous_survey,
             "survey_id_field": self.xblock.fields["survey_id"],
             "anonymous_survey_field": self.xblock.fields["anonymous_survey"],
+            "limesurvey_url_field": self.xblock.fields["limesurvey_url"],
         }
 
         self.xblock.studio_view()

--- a/limesurvey/tests/test_limesurvey.py
+++ b/limesurvey/tests/test_limesurvey.py
@@ -41,6 +41,7 @@ class TestLimeSurveyXBlock(TestCase):
         self.xblock.display_name = "Test LimeSurvey"
         self.xblock.survey_id = "test-survey-id"
         self.xblock.limesurvey_url = "test-limesurvey-url"
+        self.xblock.anonymous_survey = True
 
     @patch("limesurvey.limesurvey.Fragment")
     def test_student_view_with_survey(self, _):
@@ -122,10 +123,18 @@ class TestLimeSurveyXBlock(TestCase):
         Expected result:
             - The studio view is set up for the render.
         """
+        self.xblock.fields = {
+            "survey_id": "test-survey-id",
+            "display_name": "Test LimeSurvey",
+            "anonymous_survey": True,
+        }
         expected_context = {
             "survey_id": self.xblock.survey_id,
             "display_name": self.xblock.display_name,
             "limesurvey_url": self.xblock.limesurvey_url,
+            "anonymous_survey": self.xblock.anonymous_survey,
+            "survey_id_field": self.xblock.fields["survey_id"],
+            "anonymous_survey_field": self.xblock.fields["anonymous_survey"],
         }
 
         self.xblock.studio_view()


### PR DESCRIPTION
### Description
This PR supports anonymous surveys by ignoring the participants' table when configured as is. So now, if a survey is configured as anonymous, the user is not added to the participant table, and the token associated with the student is not generated. When configured as not anonymous survey, those things should happen.

### How to test
1. Configure a survey as anonymous in LimeSurvey: Select your survey > Participant settings > Anonymized responses
2. Configure your xblock as containing anonymous surveys
3. Check your survey in the LMS, then the iframe URL should have only the limesurvey URL without a token
4. When configuring a survey as not anonymous, it should work just as before.