### PR TITLE
feat: add list of multiple limesurvey instances from instructor tab

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,16 @@ Unreleased
 
 *
 
+0.4.0 - 2023-07-19
+**********************************************
+
+Added
+=====
+
+* Add list of multiple LimeSurvey instances from instructor tab.
+* Make instructor view configurable by Django settings.
+
+
 0.3.0 – 2023-07-12
 **********************************************
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
 LimeSurvey XBlock
-#############################
+#################
+
+|status-badge| |license-badge| |ci-badge|
 
 Purpose
 *******
@@ -11,6 +13,7 @@ learning interactives.
 
 LimeSurvey XBlock allows students to view and complete
 the different surveys assigned to them.
+
 
 Getting Started
 ***************
@@ -32,6 +35,7 @@ You can interact with the LimeSurveyXBlock in the Workbench by navigating to htt
 For details regarding how to deploy this or any other XBlock in the lms instance, see the `installing-the-xblock`_ documentation.
 
 .. _installing-the-xblock: https://edx.readthedocs.io/projects/xblock-tutorial/en/latest/edx_platform/devstack.html#installing-the-xblock
+
 
 Compatibility Notes
 ===================
@@ -60,7 +64,7 @@ These settings can be changed in ``limesurvey/settings/common.py`` or, for examp
 
 Set up LimeSurvey
 *****************
-From the LimeSurvey administrator you must enable the use of the API:
+From the LimeSurvey administrator, you must enable the use of the API:
 
 1. Login in the LimeSurvey admin → ``<LIMESURVEY_DOMAIN>/admin``
 2. Navigate to Configuration → Settings → Global → Interfaces.
@@ -70,13 +74,13 @@ From the LimeSurvey administrator you must enable the use of the API:
 Next, you must create a user with API access:
 
 1. Navigate to Configuration → Users management → Add user.
-2. Fill the form with the desired information. Doesn't set and Expire date/time and set a custom password.
-3. Select the permissions to the user.
+2. Fill the form with the desired information. Doesn't set an Expire date/time and set a custom password.
+3. Select the permissions for the user.
 
    - For the ``Surveys`` permission add permissions to ``View/read`` and ``Update``.
    - Preserve the ``Use internal database authentication`` permission.
 
-   Please, select only the permissions that are necessary, to avoid any unwanted modifications.
+   Please, select only the necessary permissions, to avoid any unwanted modifications.
 4. Save changes.
 5. Add your authentication configuration to your LMS settings.
 
@@ -86,44 +90,70 @@ Next, you must create a user with API access:
        LIMESURVEY_API_PASSWORD = "<password>"
 
 
+Configuring LimeSurvey
+**********************
+
+Survey Modes
+============
+In LimeSurvey, you can configure 2 survey modes: closed or open (anonymous).
+
+- **Closed:** Closed surveys limit access to the survey to any person, i.e., only students with
+  an access code will be able to fill it out. All surveys added to closed-access mode, must have an
+  ``attribute_1``, which allows the assignment of a unique identifier for each survey participant.
+  If this attribute is not added, students will not be able to complete the survey.
+- **Open:** Open surveys allow any student with access to the link to fill out the survey. In this mode,
+  there is no way to relate the answers to the students.
+
+
 Enabling in Studio
 ******************
 
-You can enable the LimeSurvey XBlock in the studio through the
-advanced settings.
+You can enable the LimeSurvey XBlock in the studio through the advanced settings.
 
-1. From the main page of a specific course, navigate to
-   ``Settings -> Advanced Settings`` from the top menu.
-2. Check for the ``Advanced Module List`` policy key, and add
-   ``"limesurvey"`` to the policy value list.
+.. image:: https://github.com/eduNEXT/xblock-limesurvey/assets/64033729/67f62cc9-68f5-4d96-a47c-c0ef7f7b6adb
+
+1. From the main page of a specific course, navigate to ``Settings → Advanced Settings`` from the top menu.
+2. Check for the ``Advanced Module List`` policy key, and add ``"limesurvey"`` to the policy value list.
 3. Click the "Save changes" button.
 
 
-Instructor Dashboard
-********************
-In the instructor dashboard, you can see a table containing a list
-of all the blocks added to the course by the instructor.
-This table contains the block's name and a button to access the
-administrator according to the URL of the service defined in the block.
+Configuring Component
+*********************
+.. image:: https://github.com/eduNEXT/xblock-limesurvey/assets/64033729/95f42b3d-fd30-4655-ac85-07afefa81b81
+
+Fields
+======
+- **Display name (String)**: Name of the component. This name will be displayed in the instructor dashboard.
+- **Survey ID (Integer)**: The ID of the survey to be embedded. Verify that the field value is correct,
+  otherwise, the service will display an error message from the LMS.
+- **Anonymous Survey (Boolean)**: Whether the survey is anonymous or not. By default it is set to ``False``,
+  to use anonymous surveys you must edit the block configuration and set the value to ``True``
+- **LimeSurvey URL (String)**: The URL of the LimeSurvey installation without the trailing slash. If not
+  set, it will be taken from the service configurations.
 
 
-Behavior
-**************
-1. When the URLs are not configured, the service will display an error message.
-2. When the survey ID is not valid, the service will display an error message.
+View from Learning Management System (LMS)
+******************************************
 
+As a Student
+============
+.. image:: https://github.com/eduNEXT/xblock-limesurvey/assets/64033729/b7ad78df-7cc9-4bf6-9c17-41ddd9a8171f
 
-Tips
-****
-1. All surveys added of closed-access mode, must have an ``attribute_1``, which
-   allows the assignment of a unique identifier for each survey participant.
-2. Use distinctive names for each LimeSurvey block to make it easier to identify
-   them in the instructor dashboard.
-3. The URL of the LimeSurvey installation can be edited in each block's configuration
-   in the ``Limesurvey URL`` field. If the field is empty, it will take the default
-   URL defined in the service configuration.
-4. To use anonymous surveys you should edit in the block configuration and set the
-   field ``Anonymous survey = True``.
+- The student observes the component from the LMS and will be able to complete the assigned survey.
+- The student can save the progress of the survey and complete it later. Click on "Resume later",
+  and assigns a name and password. At the next login, the progress can be loaded by clicking on
+  "Load unfinished survey"
+
+As an Instructor
+================
+.. image:: https://github.com/eduNEXT/xblock-limesurvey/assets/64033729/0cd3630e-becf-4eaf-ad87-ce0101b11b51
+
+The instructor can access the instructor dashboard. In the instructor dashboard, you can see a table with
+the following columns:
+
+- **Component name:** This is the name assigned to each component in the ``Display name`` field.
+- **Management Console(s):** This is the URL of the administrator assigned to each component in the
+  ``LimeSurvey URL`` field.
 
 
 Getting Help
@@ -151,6 +181,7 @@ For more information about these options, see the `Getting Help`_ page.
 .. _community Slack workspace: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
 
+
 License
 *******
 
@@ -158,6 +189,7 @@ The code in this repository is licensed under the AGPL-3.0 unless
 otherwise noted.
 
 Please see `LICENSE.txt <LICENSE.txt>`_ for details.
+
 
 Contributing
 ************
@@ -171,6 +203,7 @@ to have a discussion about your new feature idea with the maintainers prior to
 beginning development to maximize the chances of your change being accepted.
 You can start a conversation by creating a new issue on this repo summarizing
 your idea.
+
 
 The Open edX Code of Conduct
 ****************************
@@ -188,33 +221,30 @@ file in this repo.
 
 .. _Backstage: https://backstage.openedx.org/catalog/default/component/{{ cookiecutter.repo_name }}
 
+
 Reporting Security Issues
 *************************
 
 Please do not report security issues in public. Please email security@tcril.org.
 
-.. |pypi-badge| image:: https://img.shields.io/pypi/v/{{ cookiecutter.repo_name }}.svg
-    :target: https://pypi.python.org/pypi/{{ cookiecutter.repo_name }}/
+.. |pypi-badge| image:: https://img.shields.io/pypi/v/xblock-limesurvey.svg
+    :target: https://pypi.python.org/pypi/xblock-limesurvey/
     :alt: PyPI
 
-.. |ci-badge| image:: https://github.com/openedx/{{ cookiecutter.repo_name }}/workflows/Python%20CI/badge.svg?branch=main
-    :target: https://github.com/openedx/{{ cookiecutter.repo_name }}/actions
+.. |ci-badge| image:: https://github.com/eduNEXT/xblock-limesurvey/workflows/Python%20CI/badge.svg?branch=main
+    :target: https://github.com/eduNEXT/xblock-limesurvey/actions
     :alt: CI
 
-.. |codecov-badge| image:: https://codecov.io/github/openedx/{{ cookiecutter.repo_name }}/coverage.svg?branch=main
-    :target: https://codecov.io/github/openedx/{{ cookiecutter.repo_name }}?branch=main
+.. |codecov-badge| image:: https://codecov.io/github/eduNEXT/xblock-limesurvey/coverage.svg?branch=main
+    :target: https://codecov.io/github/eduNEXT/xblock-limesurvey?branch=main
     :alt: Codecov
 
-.. |doc-badge| image:: https://readthedocs.org/projects/{{ cookiecutter.repo_name }}/badge/?version=latest
-    :target: https://docs.openedx.org/projects/{{ cookiecutter.repo_name }}
-    :alt: Documentation
-
-.. |pyversions-badge| image:: https://img.shields.io/pypi/pyversions/{{ cookiecutter.repo_name }}.svg
-    :target: https://pypi.python.org/pypi/{{ cookiecutter.repo_name }}/
+.. |pyversions-badge| image:: https://img.shields.io/pypi/pyversions/xblock-limesurvey.svg
+    :target: https://pypi.python.org/pypi/xblock-limesurvey/
     :alt: Supported Python versions
 
-.. |license-badge| image:: https://img.shields.io/github/license/openedx/{{ cookiecutter.repo_name }}.svg
-    :target: https://github.com/openedx/{{ cookiecutter.repo_name }}/blob/main/LICENSE.txt
+.. |license-badge| image:: https://img.shields.io/github/license/eduNEXT/xblock-limesurvey.svg
+    :target: https://github.com/eduNEXT/xblock-limesurvey/blob/main/LICENSE.txt
     :alt: License
 
 .. TODO: Choose one of the statuses below and remove the other status-badge lines.

--- a/README.rst
+++ b/README.rst
@@ -85,10 +85,11 @@ Next, you must create a user with API access:
        LIMESURVEY_API_USER = "<username>"
        LIMESURVEY_API_PASSWORD = "<password>"
 
+
 Enabling in Studio
 ******************
 
-You can enable the LimeSurvey XBlock in studio through the
+You can enable the LimeSurvey XBlock in the studio through the
 advanced settings.
 
 1. From the main page of a specific course, navigate to
@@ -96,6 +97,34 @@ advanced settings.
 2. Check for the ``Advanced Module List`` policy key, and add
    ``"limesurvey"`` to the policy value list.
 3. Click the "Save changes" button.
+
+
+Instructor Dashboard
+********************
+In the instructor dashboard, you can see a table containing a list
+of all the blocks added to the course by the instructor.
+This table contains the block's name and a button to access the
+administrator according to the URL of the service defined in the block.
+
+
+Behavior
+**************
+1. When the URLs are not configured, the service will display an error message.
+2. When the survey ID is not valid, the service will display an error message.
+
+
+Tips
+****
+1. All surveys added of closed-access mode, must have an ``attribute_1``, which
+   allows the assignment of a unique identifier for each survey participant.
+2. Use distinctive names for each LimeSurvey block to make it easier to identify
+   them in the instructor dashboard.
+3. The URL of the LimeSurvey installation can be edited in each block's configuration
+   in the ``Limesurvey URL`` field. If the field is empty, it will take the default
+   URL defined in the service configuration.
+4. To use anonymous surveys you should edit in the block configuration and set the
+   field ``Anonymous survey = True``.
+
 
 Getting Help
 ************

--- a/limesurvey/__init__.py
+++ b/limesurvey/__init__.py
@@ -5,6 +5,6 @@ import os
 from pathlib import Path
 from .limesurvey import LimeSurveyXBlock
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 
 LIMESURVEY_ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/limesurvey/extensions/filters.py
+++ b/limesurvey/extensions/filters.py
@@ -4,7 +4,6 @@ Open edX Filters needed for LimeSurvey integration.
 from crum import get_current_request
 from django.conf import settings
 from openedx_filters import PipelineStep
-from django.conf import settings
 
 from limesurvey.edxapp_wrapper.courseware import get_object_by_usage_id
 from limesurvey.edxapp_wrapper.xmodule import modulestore

--- a/limesurvey/extensions/filters.py
+++ b/limesurvey/extensions/filters.py
@@ -43,7 +43,6 @@ class AddInstructorLimesurveyTab(PipelineStep):
             disable_staff_debug_info=True, course=course
         )
 
-        # Get display name and url for each LimeSurvey block
         limesurvey_url = getattr(settings, "LIMESURVEY_URL", None)
         xblock_urls = [
             (block.display_name, block.limesurvey_url or limesurvey_url)

--- a/limesurvey/extensions/filters.py
+++ b/limesurvey/extensions/filters.py
@@ -20,7 +20,7 @@ class AddInstructorLimesurveyTab(PipelineStep):
 
         Args:
             context (dict): the context for the instructor dashboard.
-            _ (str): instructor dashboard template name.
+            template_name (str): instructor dashboard template name.
         """
         if not settings.FEATURES.get("ENABLE_LIMESURVEY_INSTRUCTOR_VIEW", False):
             return context

--- a/limesurvey/extensions/filters.py
+++ b/limesurvey/extensions/filters.py
@@ -4,6 +4,7 @@ Open edX Filters needed for LimeSurvey integration.
 from crum import get_current_request
 from django.conf import settings
 from openedx_filters import PipelineStep
+from django.conf import settings
 
 from limesurvey.edxapp_wrapper.courseware import get_object_by_usage_id
 from limesurvey.edxapp_wrapper.xmodule import modulestore
@@ -41,8 +42,16 @@ class AddInstructorLimesurveyTab(PipelineStep):
             request, str(course.id), str(limesurvey_block.location),
             disable_staff_debug_info=True, course=course
         )
+
+        # Get display name and url for each LimeSurvey block
+        limesurvey_url = getattr(settings, "LIMESURVEY_URL", None)
+        xblock_urls = [
+            (block.display_name, block.limesurvey_url or limesurvey_url)
+            for block in limesurvey_blocks
+        ]
+
         section_data = {
-            "fragment": block.render("instructor_view", context={}),
+            "fragment": block.render("instructor_view", context={"xblock_urls": xblock_urls}),
             "section_key": LIMESURVEY_BLOCK_CATEGORY,
             "section_display_name": "LimeSurvey",
             "course_id": str(course.id),

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -476,11 +476,11 @@ class LimeSurveyXBlock(XBlock):
 
         return result
 
-    def instructor_view(self, context=None):
+    def instructor_view(self, context: dict):
         """
         The studio view of the LimeSurveyXBlock, shown to instructors.
         """
-        context = {"limesurvey_url": getattr(settings, "LIMESURVEY_URL", None)}
+        context.update({"limesurvey_url": getattr(settings, "LIMESURVEY_URL", None)})
         html = self.render_template("static/html/instructor.html", context)
         frag = Fragment(html)
         frag.add_css(self.resource_string("static/css/instructor.css"))

--- a/limesurvey/settings/test.py
+++ b/limesurvey/settings/test.py
@@ -57,3 +57,8 @@ LIMESURVEY_INTERNAL_API = "https://test-url.com/index.php/admin/remotecontrol"
 # Limesurvey backend settings
 LIMESURVEY_COURSEWARE_BACKEND = "limesurvey.edxapp_wrapper.backends.courseware_p_v1"
 LIMESURVEY_XMODULE_BACKEND = "limesurvey.edxapp_wrapper.backends.xmodule_p_v1"
+
+# LimeSurvey features settings
+FEATURES = {
+    "ENABLE_LIMESURVEY_INSTRUCTOR_VIEW": True
+}

--- a/limesurvey/static/css/instructor.css
+++ b/limesurvey/static/css/instructor.css
@@ -12,10 +12,3 @@
 .go-back {
     margin: 16px 0px 16px 0px;
 }
-
-table.limesurvey-xblocks-table th,
-table.limesurvey-xblocks-table td {
-    border: 1px solid black;
-    padding: 8px;
-    text-align: left;
-}

--- a/limesurvey/static/css/instructor.css
+++ b/limesurvey/static/css/instructor.css
@@ -1,3 +1,18 @@
+.limesurvey-instructor-wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.limesurvey-instructor-wrapper iframe {
+    width: 100%;
+    height: 100vh;
+}
+
+.go-back {
+    margin: 16px 0px 16px 0px;
+}
+
 table.limesurvey-xblocks-table th,
 table.limesurvey-xblocks-table td {
     border: 1px solid black;

--- a/limesurvey/static/css/instructor.css
+++ b/limesurvey/static/css/instructor.css
@@ -1,13 +1,6 @@
-.limesurvey-instructor-wrapper {
-    position: relative;
-    width: 100%;
-    padding-bottom: 56.25%;
-}
-
-.limesurvey-instructor-wrapper iframe {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
+table.limesurvey-xblocks-table th,
+table.limesurvey-xblocks-table td {
+    border: 1px solid black;
+    padding: 8px;
+    text-align: left;
 }

--- a/limesurvey/static/html/instructor.html
+++ b/limesurvey/static/html/instructor.html
@@ -1,3 +1,18 @@
-<div class="limesurvey-instructor-wrapper">
-    <iframe class="limesurvey-admin-iframe" src="{{limesurvey_url}}/admin/" frameborder="0"></iframe>
-</div>
+<table class="limesurvey-xblocks-table">
+    <thead>
+        <tr>
+            <th>Component</th>
+            <th>Management Console</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for name, url in xblock_urls %}
+        <tr>
+            <td>{{ name }}</td>
+            <td>
+               <a href="{{ url }}/admin/"><button type="button">{{ url }}</button></a>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/limesurvey/static/html/instructor.html
+++ b/limesurvey/static/html/instructor.html
@@ -34,6 +34,7 @@
     </div>
   </div>
 
+<!-- This script is because it's currently not possible to add sections dinamically from the frontend. -->
 <script type="text/javascript">
     $(function () {
         $('.limesurvey-instructor-wrapper').hide();
@@ -51,10 +52,10 @@
                     </iframe>
                 </div>
             `);
-            $('.limesurvey-xblocks-table').hide();
+            $('.paragon-styles').hide();
             $('.go-back').click(function (e) {
                 e.preventDefault();
-                $('.limesurvey-xblocks-table').show();
+                $('.paragon-styles').show();
                 $('.limesurvey-instructor-wrapper').html('');
                 $(this).hide();
             });

--- a/limesurvey/static/html/instructor.html
+++ b/limesurvey/static/html/instructor.html
@@ -1,3 +1,4 @@
+<div class="limesurvey-instructor-wrapper"></div>
 <table class="limesurvey-xblocks-table">
     <thead>
         <tr>
@@ -10,9 +11,37 @@
         <tr>
             <td>{{ name }}</td>
             <td>
-               <a href="{{ url }}/admin/"><button type="button">{{ url }}</button></a>
+                <a class="admin-panel" href="{{ url }}/admin/"><button type="button">Management Console</button></a>
             </td>
         </tr>
         {% endfor %}
     </tbody>
 </table>
+
+<script type="text/javascript">
+    $(function () {
+        $('.limesurvey-instructor-wrapper').hide();
+        $('.admin-panel').click(function (e) {
+            e.preventDefault();
+            $('.limesurvey-instructor-wrapper').show();
+            const url = $(this).attr('href');
+            $('.limesurvey-instructor-wrapper').append(`
+                <a href="" class="go-back">Back</a>
+                <div>
+                    <iframe
+                        class="limesurvey-admin-iframe"
+                        frameborder="0"
+                        src="${url}">
+                    </iframe>
+                </div>
+            `);
+            $('.limesurvey-xblocks-table').hide();
+            $('.go-back').click(function (e) {
+                e.preventDefault();
+                $('.limesurvey-xblocks-table').show();
+                $('.limesurvey-instructor-wrapper').html('');
+                $(this).hide();
+            });
+        })
+    });
+</script>

--- a/limesurvey/static/html/instructor.html
+++ b/limesurvey/static/html/instructor.html
@@ -6,12 +6,12 @@
           <tr role="row">
             <th colspan="1" role="columnheader">
               <span class="d-flex align-items-center"
-                ><span>Component</span></span
+                ><span>Component name</span></span
               >
             </th>
             <th colspan="1" role="columnheader">
               <span class="d-flex align-items-center"
-                ><span>Management Console</span></span
+                ><span>Management Console(s)</span></span
               >
             </th>
           </tr>

--- a/limesurvey/static/html/instructor.html
+++ b/limesurvey/static/html/instructor.html
@@ -1,22 +1,38 @@
 <div class="limesurvey-instructor-wrapper"></div>
-<table class="limesurvey-xblocks-table">
-    <thead>
-        <tr>
-            <th>Component</th>
-            <th>Management Console</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for name, url in xblock_urls %}
-        <tr>
-            <td>{{ name }}</td>
-            <td>
-                <a class="admin-panel" href="{{ url }}/admin/"><button type="button">Management Console</button></a>
+<div class="paragon-styles">
+    <div class="pgn__data-table-container">
+      <table role="table" class="pgn__data-table is-striped">
+        <thead>
+          <tr role="row">
+            <th colspan="1" role="columnheader">
+              <span class="d-flex align-items-center"
+                ><span>Component</span></span
+              >
+            </th>
+            <th colspan="1" role="columnheader">
+              <span class="d-flex align-items-center"
+                ><span>Management Console</span></span
+              >
+            </th>
+          </tr>
+        </thead>
+        <tbody role="rowgroup">
+          {% for name, url in xblock_urls %}
+          <tr role="row" class="pgn__data-table-row">
+            <td role="cell" class="pgn__data-table-cell-wrap">{{ name }}</td>
+            <td role="cell" class="pgn__data-table-cell-wrap">
+              <a class="admin-panel" href="{{ url }}/admin/"
+                ><button class="btn btn-primary" ="button">
+                  Management Console
+                </button></a
+              >
             </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
 
 <script type="text/javascript">
     $(function () {
@@ -26,7 +42,7 @@
             $('.limesurvey-instructor-wrapper').show();
             const url = $(this).attr('href');
             $('.limesurvey-instructor-wrapper').append(`
-                <a href="" class="go-back">Back</a>
+                <a href="" class="go-back">← Back</a>
                 <div>
                     <iframe
                         class="limesurvey-admin-iframe"

--- a/limesurvey/tests/test_limesurvey.py
+++ b/limesurvey/tests/test_limesurvey.py
@@ -157,7 +157,7 @@ class TestLimeSurveyXBlock(TestCase):
             "limesurvey_url": getattr(settings, "LIMESURVEY_URL", None),
         }
 
-        self.xblock.instructor_view()
+        self.xblock.instructor_view({})
 
         self.xblock.render_template.assert_called_once_with(
             "static/html/instructor.html",

--- a/limesurvey/tests/test_limesurvey.py
+++ b/limesurvey/tests/test_limesurvey.py
@@ -19,6 +19,53 @@ from limesurvey.limesurvey import (
     MisconfiguredLimeSurveyService,
 )
 
+from limesurvey.extensions.filters import AddInstructorLimesurveyTab
+
+class TestFilters(TestCase):
+    """
+    Test suite for the LimeSurveyXBlock filters.
+    """
+
+    def setUp(self) -> None:
+        """
+        Set up the test suite.
+        """
+        self.filter = AddInstructorLimesurveyTab(filter_type=Mock(), running_pipeline=Mock())
+
+    @patch("limesurvey.extensions.filters.get_object_by_usage_id")
+    @patch("limesurvey.extensions.filters.modulestore")
+    def test_run_filter_without_blocks(self, modulestore_mock, get_object_by_usage_id_mock):
+        """
+        Check the filter is not executed when there are no LimeSurvey blocks in the course.
+
+        Expected result:
+            - The context is returned without modifications.
+        """
+        modulestore_mock().get_items.return_value = []
+        context = {"course": Mock(id="test-course-id"), "sections": []}
+        template_name = "test-template-name"
+
+        self.filter.run_filter(context, template_name)
+
+        get_object_by_usage_id_mock.assert_not_called()
+
+    @patch("limesurvey.extensions.filters.get_object_by_usage_id")
+    @patch("limesurvey.extensions.filters.modulestore")
+    def test_run_filter_with_blocks(self, modulestore_mock, get_object_by_usage_id_mock):
+        """
+        Check the filter is executed when there are LimeSurvey blocks in the course.
+
+        Expected result:
+            - The context is returned with the LimeSurvey blocks information.
+        """
+        modulestore_mock().get_items.return_value = [Mock(location="test-location")]
+        context = {"course": Mock(id="test-course-id"), "sections": []}
+        template_name = "test-template-name"
+
+        context = self.filter.run_filter(context, template_name)
+
+        get_object_by_usage_id_mock.assert_called_once()
+        self.assertEqual(1, len(context["sections"]))
 
 class TestLimeSurveyXBlock(TestCase):
     """


### PR DESCRIPTION
### Description
This PR adds a table from the instructor tab with a list of all limesurvey blocks and their custom instance. For each instance you can enter the corresponding management console.

**Note**: The functionality to display the iframe according to the block URL is added directly in the HTML. This is because currently it is only possible to add sections dynamically from the Back-end, but not from the Front-end.

### How to test
1. Install the LimeSurvey Xblock in the LMS/CMS services: `git@github.com:eduNEXT/xblock-limesurvey.git@bav/multiple-limesurvey-instances`
2. Install the Open edX filters in the LMS/CMS services: `git+https://github.com/openedx/openedx-filters.git@MJG/instructor-tab-filters`
3. Change your `edx-platform` branch to `MJG/instructor-filter`
4. Add the Open edX Filters configuration to your environment. Add this code in `env/apps/openedx/settings/lms/development.py` or `env/apps/openedx/settings/lms/production.py` (depending on your case):
    ```python
    OPEN_EDX_FILTERS_CONFIG = {
        "org.openedx.learning.instructor.dashboard.render.started.v1": {
            "fail_silently": False,
            "pipeline": [
                "limesurvey.extensions.filters.AddInstructorLimesurveyTab",
            ]
        },
    }
    ```
    Another option is to create a plugin in `plugin/<plugin_name>.py` and enable it with `tutor plugins enable <plugin_name>` and `tutor config save`
5. Restart services.
6. Add the LimeSurvey Xblock as a component of your course, you can use dummy values for the Studio configuration. The student view doesn't really matter for these tests.
7. Go to the instructor dashboard with the proper permissions (as an instructor of the course). You'll see:
![image](https://github.com/eduNEXT/xblock-limesurvey/assets/64033729/3d062e77-a278-4c03-b93e-806d9ab6281f)
