### PR TITLE
fix: load paragon styles in instructor dashboard

### DIFF
--- a/limesurvey/static/html/instructor.html
+++ b/limesurvey/static/html/instructor.html
@@ -35,30 +35,4 @@
   </div>
 
 <!-- This script is because it's currently not possible to add sections dinamically from the frontend. -->
-<script type="text/javascript">
-    $(function () {
-        $('.limesurvey-instructor-wrapper').hide();
-        $('.admin-panel').click(function (e) {
-            e.preventDefault();
-            $('.limesurvey-instructor-wrapper').show();
-            const url = $(this).attr('href');
-            $('.limesurvey-instructor-wrapper').append(`
-                <a href="" class="go-back">← Back</a>
-                <div>
-                    <iframe
-                        class="limesurvey-admin-iframe"
-                        frameborder="0"
-                        src="${url}">
-                    </iframe>
-                </div>
-            `);
-            $('.paragon-styles').hide();
-            $('.go-back').click(function (e) {
-                e.preventDefault();
-                $('.paragon-styles').show();
-                $('.limesurvey-instructor-wrapper').html('');
-                $(this).hide();
-            });
-        })
-    });
-</script>
+<script type="text/javascript" src="/limesurvey/static/js/src/instructor.js"></script>

--- a/limesurvey/static/js/src/instructor.js
+++ b/limesurvey/static/js/src/instructor.js
@@ -1,14 +1,33 @@
-/* Javascript for LimeSurveyTab. */
-function LimeSurveyTab(runtime, element) {
+$(function () {
 
-    $(function ($) {
-        /*
-        Use `gettext` provided by django-statici18n for static translations
+    const cssUrl = "https://cdn.jsdelivr.net/npm/@edx/paragon@20.45.5/dist/paragon.min.css";
 
-        var gettext = LimeSurveyXBlocki18n.gettext;
-        */
+    $('<link>').attr({
+        href: cssUrl,
+        rel: "stylesheet"
+    }).appendTo('head');
 
-        /* Here's where you'd do things on page load. */
-        console.log("LimeSurveyTab");
-    });
-}
+    $('.limesurvey-instructor-wrapper').hide();
+    $('.admin-panel').click(function (e) {
+        e.preventDefault();
+        $('.limesurvey-instructor-wrapper').show();
+        const url = $(this).attr('href');
+        $('.limesurvey-instructor-wrapper').append(`
+            <a href="" class="go-back">← Back</a>
+            <div>
+                <iframe
+                    class="limesurvey-admin-iframe"
+                    frameborder="0"
+                    src="${url}">
+                </iframe>
+            </div>
+        `);
+        $('.paragon-styles').hide();
+        $('.go-back').click(function (e) {
+            e.preventDefault();
+            $('.paragon-styles').show();
+            $('.limesurvey-instructor-wrapper').html('');
+            $(this).hide();
+        });
+    })
+});


### PR DESCRIPTION
### Description
This PR load paragon styles from CDN in the instructor dashboard.

### How to Test
Try entering the instructor dashboard from a new course with LimeSurvey XBlock only.

#### Before
![image](https://github.com/eduNEXT/xblock-limesurvey/assets/64033729/b3cb4e1e-fbe2-4d0e-a015-131a6218baa3)

#### After
![image](https://github.com/eduNEXT/xblock-limesurvey/assets/64033729/00e472bc-6fec-4b63-b2f8-d0777f9bcc20)