### PR TITLE
refactor: make API credentials configurable for each installation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,24 @@ Change Log
 Unreleased
 **********
 
-* Add better field descriptions in the studio edit view.
-* Add support for older LimeSurvey versions (< 6.1.0).
+0.5.0 - 2023-08-04
+**********************************************
+
+Added
+=====
+
+* Better field descriptions in the studio edit view.
+* Support for older LimeSurvey versions (< 6.1.0).
+* Support for LimeSurvey API configurable credentials.
+
+0.4.1 - 2023-07-25
+**********************************************
+
+Changed
+=======
+
+* Load paragon styles in instructor dashboard.
+
 
 0.4.0 - 2023-07-19
 **********************************************

--- a/limesurvey/__init__.py
+++ b/limesurvey/__init__.py
@@ -5,6 +5,6 @@ import os
 from pathlib import Path
 from .limesurvey import LimeSurveyXBlock
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 LIMESURVEY_ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -449,11 +449,10 @@ class LimeSurveyXBlock(XBlock):
                 settings, "LIMESURVEY_LOGIN_ATTEMPTS_TIMEOUT", 5,
             )
         )
-        # if login_attempts_exceeded:
-        #     raise ExceededLoginAttempts
+        if login_attempts_exceeded:
+            raise ExceededLoginAttempts
 
         self.last_login_attempt = datetime.now()
-        import pudb; pudb.set_trace()
         limesurvey_api_user = self.api_username or getattr(settings, "LIMESURVEY_API_USER", None)
         limesurvey_api_password = self.api_password or getattr(settings, "LIMESURVEY_API_PASSWORD", None)
         if not limesurvey_api_user or not limesurvey_api_password:

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -133,6 +133,24 @@ class LimeSurveyXBlock(XBlock):
         """,
     )
 
+    api_username = String(
+        display_name="API username",
+        default="",
+        scope=Scope.settings,
+        help="""The username to authenticate with your LimeSurvey installation you set in LimeSurvey URL.
+        If not set, it will be taken from the service configurations.
+        """,
+    )
+
+    api_password = String(
+        display_name="API user's password",
+        default="",
+        scope=Scope.settings,
+        help="""The password to authenticate with your LimeSurvey installation you set in LimeSurvey URL.
+        If not set, it will be taken from the service configurations.
+        """,
+    )
+
     anonymous_survey = Boolean(
         default=False,
         scope=Scope.settings,
@@ -263,6 +281,8 @@ class LimeSurveyXBlock(XBlock):
             "survey_id_field": self.fields["survey_id"],
             "anonymous_survey_field": self.fields["anonymous_survey"],
             "limesurvey_url_field": self.fields["limesurvey_url"],
+            "api_username_field": self.fields["api_username"],
+            "api_password_field": self.fields["api_password"],
         }
 
         html = self.render_template("static/html/limesurvey_edit.html", context)
@@ -286,6 +306,8 @@ class LimeSurveyXBlock(XBlock):
         self.display_name = data.get("display_name")
         self.survey_id = data.get("survey_id")
         self.limesurvey_url = data.get("limesurvey_url")
+        self.api_username = data.get("api_username")
+        self.api_password = data.get("api_password")
         self.anonymous_survey = bool(data.get("anonymous_survey"))
 
     def get_survey_summary(self) -> dict:
@@ -414,13 +436,13 @@ class LimeSurveyXBlock(XBlock):
                 settings, "LIMESURVEY_LOGIN_ATTEMPTS_TIMEOUT", 5,
             )
         )
-        if login_attempts_exceeded:
-            raise ExceededLoginAttempts
+        # if login_attempts_exceeded:
+        #     raise ExceededLoginAttempts
 
         self.last_login_attempt = datetime.now()
-
-        limesurvey_api_user = getattr(settings, "LIMESURVEY_API_USER", None)
-        limesurvey_api_password = getattr(settings, "LIMESURVEY_API_PASSWORD", None)
+        import pudb; pudb.set_trace()
+        limesurvey_api_user = self.api_username or getattr(settings, "LIMESURVEY_API_USER", None)
+        limesurvey_api_password = self.api_password or getattr(settings, "LIMESURVEY_API_PASSWORD", None)
         if not limesurvey_api_user or not limesurvey_api_password:
             raise MisconfiguredLimeSurveyService("LimeSurvey API user or password not configured")
 

--- a/limesurvey/settings/common.py
+++ b/limesurvey/settings/common.py
@@ -11,8 +11,8 @@ def plugin_settings(settings):
     settings.MAKO_TEMPLATE_DIRS_BASE.append(LIMESURVEY_ROOT_DIRECTORY / "templates")
     # Timeout configured to 5s as the average timeout for regular HTTP request
     settings.LIMESURVEY_API_TIMEOUT = 5
-    settings.LIMESURVEY_API_USER = "CHANGE-ME"
-    settings.LIMESURVEY_API_PASSWORD = "CHANGE-ME"
+    settings.LIMESURVEY_API_USER = None
+    settings.LIMESURVEY_API_PASSWORD = None
 
     # Limesurvey backend settings
     settings.LIMESURVEY_COURSEWARE_BACKEND = "limesurvey.edxapp_wrapper.backends.courseware_p_v1"

--- a/limesurvey/static/html/limesurvey_edit.html
+++ b/limesurvey/static/html/limesurvey_edit.html
@@ -31,6 +31,20 @@
       </div>
       <span class="tip setting-help"> {{ limesurvey_url_field.help }} </span>
     </li>
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="limesurvey_api_username">LimeSurvey API username</label>
+        <input class="input setting-input" name="limesurvey_api_username" id="limesurvey_api_username" value="{{api_username}}" type="text" />
+      </div>
+      <span class="tip setting-help"> {{ api_username_field.help }} </span>
+    </li>
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="limesurvey_api_password">LimeSurvey API password</label>
+        <input class="input setting-input" name="limesurvey_api_password" id="limesurvey_api_password" value="{{api_password}}" type="text" />
+      </div>
+      <span class="tip setting-help"> {{ api_password_field.help }} </span>
+    </li>
   </ul>
 
   <div class="xblock-actions">

--- a/limesurvey/static/js/src/limesurveyEdit.js
+++ b/limesurvey/static/js/src/limesurveyEdit.js
@@ -7,6 +7,8 @@ function LimeSurveyXBlock(runtime, element) {
             display_name: $(element).find('input[name=limesurvey_display_name]').val(),
             survey_id: $(element).find('input[name=limesurvey_survey_id]').val(),
             limesurvey_url: $(element).find('input[name=limesurvey_url]').val(),
+            api_username: $(element).find('input[name=limesurvey_api_username]').val(),
+            api_password: $(element).find('input[name=limesurvey_api_password]').val(),
             anonymous_survey: Number($(element).find('select[name=limesurvey_anonymous_survey]').val()),
         };
         $.post(handlerUrl, JSON.stringify(data)).done(function(response) {


### PR DESCRIPTION
### Description
This PR makes the LimeSurvey credentials configurable for each installation specified in LimeSurvey URL. 

### How to test
1. Install this version in your development environment using the method you're most comfortable with.
2. Install tutor-contrib-limesurvey. Follow [these instructions](https://github.com/eduNEXT/tutor-contrib-limesurvey/#limesurvey-plugin-for-tutor) to do so.
3. Create a new survey, write down its survey ID for the Xblock configuration. Create an anonymoys/non anonymous surveys so you can test both
4. Add it as a new Xblock to your course.
5. Create your credentials in the LimeSurvey service: https://github.com/eduNEXT/xblock-limesurvey#set-up-limesurvey
6. Add the API credentials and LimeSurvey URL in the block configuration when configuring it
7. Finish configuring the Xblock and then publish it into your course
8. Visit the LMS as a student, it should show the survey