### PR TITLE
refactor: add hardcoded index.php so survey path works in older versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Unreleased
 **********
 
 * Add better field descriptions in the studio edit view.
+* Add support for older LimeSurvey versions (< 6.1.0).
 
 0.4.0 - 2023-07-19
 **********************************************

--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -208,7 +208,7 @@ class LimeSurveyXBlock(XBlock):
         if not limesurvey_url:
             raise MisconfiguredLimeSurveyService("LIMESURVEY_URL is not set in your service configurations.")
 
-        self.survey_url = f"{limesurvey_url}/{self.survey_id}"
+        self.survey_url = f"{limesurvey_url}/index.php/{self.survey_id}"
         self.set_session_key()
 
         if not self.anonymous_survey:


### PR DESCRIPTION
### Description
This PR makes embedding surveys from older LimeSurvey services possible.

More context:  

> Doing some testing and reviewing the code currently in the XBlock, when trying to render the iframe with the survey URL from the LMS it will fail on older versions of LimeSurvey, like the 5.6.26 they use, why?
> 
> In our code, we have the following:
> self.survey_url = f"{limesurvey_url}/{self.survey_id}"
> 
> This is the survey URL we render in the iframe. This works fine in the version we currently use (6.1.0), but not in 5.6.26. For example, if we try to access this URL:
> 
> https://surveys.example.com/123456
> 
> We get a Not Found. However if we go to:
> 
> https://surveys.example.com/index.php/795133
> 
> It allows us to enter the survey.
> 
> The solution would be to add the prefix /index.php before the ID of the survey, and thus we ensure that both versions work.

### How to test
First, you can access https://surveys.example.com/123456 and https://surveys.example.com/index.php/123456 to test that in our current remote installations you can access both surveys.