### PR TITLE
refactor: call API when the survey is anonymous only

### DIFF
--- a/limesurvey/limesurvey.py
+++ b/limesurvey/limesurvey.py
@@ -209,9 +209,9 @@ class LimeSurveyXBlock(XBlock):
             raise MisconfiguredLimeSurveyService("LIMESURVEY_URL is not set in your service configurations.")
 
         self.survey_url = f"{limesurvey_url}/index.php/{self.survey_id}"
-        self.set_session_key()
 
         if not self.anonymous_survey:
+            self.set_session_key()
             self.add_participant_to_survey(user, anonymous_user_id)
             self.set_student_access_code(anonymous_user_id)
 


### PR DESCRIPTION
### Description
This PR refactors the student view setup so interactions with the LimeSurvey API only occur when the xblock needs to communicate with the remote LimeSurvey API, eg. for authentication, adding participants to survey, etc.

### How to test
1. You need to setup your LimeSurvey service first. Follow these instructions!
2. Create an anonymous survey: Select your survey > Participant settings > Anonymized responses
3. Go to the LMS as a student after configuring your LimeSurvey block. The survey should appear. 
Try it as well with non-anonymous surveys!
