### PR TITLE
refactor: return arguments so multiple filters can be executed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Unreleased
 
 *
 
+0.6.3 - 2023-10-04
+**********************************************
+
+Changed
+=======
+
+* Return dictionary so filter can be used along with other filters.
+
 0.6.2 - 2023-09-11
 **********************************************
 

--- a/limesurvey/__init__.py
+++ b/limesurvey/__init__.py
@@ -5,6 +5,6 @@ import os
 from pathlib import Path
 from .limesurvey import LimeSurveyXBlock
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 LIMESURVEY_ROOT_DIRECTORY = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/limesurvey/extensions/filters.py
+++ b/limesurvey/extensions/filters.py
@@ -56,4 +56,7 @@ class AddInstructorLimesurveyTab(PipelineStep):
             "template_path_prefix": INSTRUCTOR_TEMPLATE_ABSOLUTE_PATH,
         }
         context["sections"].append(section_data)
-        return context
+        return {
+            "context": context,
+            "template_name": template_name,
+        }

--- a/limesurvey/tests/test_limesurvey.py
+++ b/limesurvey/tests/test_limesurvey.py
@@ -62,10 +62,10 @@ class TestFilters(TestCase):
         context = {"course": Mock(id="test-course-id"), "sections": []}
         template_name = "test-template-name"
 
-        context = self.filter.run_filter(context, template_name)
+        result = self.filter.run_filter(context, template_name)
 
         get_object_by_usage_id_mock.assert_called_once()
-        self.assertEqual(1, len(context["sections"]))
+        self.assertEqual(1, len(result.get("context", {})["sections"]))
 
 class TestLimeSurveyXBlock(TestCase):
     """


### PR DESCRIPTION
### Description
This PR allows executing multiple pipeline steps alongside this one. If the pipeline doesn't return what receives, then it cannot interact with other filters.